### PR TITLE
Create hostgroups requires zabbix_api

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,6 +37,7 @@
     login_password: "{{ zabbix_api_pass }}"
     host_groups: "{{ zabbix_host_groups }}"
     state: "{{ zabbix_create_hostgroup }}"
+  when: zabbix_api_use == True
 
 - name: "Create a new host or update an existing host's info"
   local_action:


### PR DESCRIPTION
Create hostgroups tasks should be called only when zabbix_api_use is true