### PR TITLE
defaults/main.yml is not in line with the README

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -32,7 +32,7 @@ agent_sourceip:
 agent_enableremotecommands: 0
 agent_logremotecommands: 0
 agent_listenport: 10050
-agent_listeninterface: eth1
+agent_listeninterface: eth0
 agent_listenip: 
 agent_startagents: 3
 agent_hostname: 


### PR DESCRIPTION
The README.md file states that the default is eth0.