### PR TITLE
enable use of EPEL packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ You can install so-called userparameter files by adding the following into your 
         owner=zabbix
         group=zabbix
         mode=0755
-  notify: "{{ zabbix_agent_service }} restarted"
+  notify: restart zabbix-agent
 ```
 
 Example of the "sample.conf" file:

--- a/README.md
+++ b/README.md
@@ -64,7 +64,10 @@ There are some variables in de default/main.yml which can (Or needs to) be chang
 
 * `zabbix_version`: This is the version of zabbix. Default it is 2.4, but can be overriden to 2.2 or 2.0.
 
-* `zabbix_repo`: When you already have an repository with the zabbix components, you can set it to False.
+* `zabbix_repo`: Default: _epel_
+  * _epel_ (default) install agent from EPEL repo
+  * _zabbix_ install agent from Zabbix repo
+  * _other_ install agent from pre-existing or other repo
 
 * `agent_listeninterface`: On which interface zabbix-agent is listening. Default: eth0
 
@@ -162,7 +165,7 @@ You can install so-called userparameter files by adding the following into your 
         owner=zabbix
         group=zabbix
         mode=0755
-  notify: "{{ zabbix_agent }} restarted"
+  notify: "{{ zabbix_agent_service }} restarted"
 ```
 
 Example of the "sample.conf" file:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,9 @@
 # defaults file for zabbix-agent
 
 zabbix_version: 2.4
-zabbix_repo: True
+zabbix_repo: epel
+zabbix_agent_package: zabbix-agent
+zabbix_agent_service: zabbix-agent
 agent_server:
 agent_serveractive:
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,8 +1,8 @@
 ---
 # handlers file for zabbix-agent
 
-- name: "{{ zabbix_agent }} restarted"
-  service: name={{ zabbix_agent }}
+- name: "{{ zabbix_agent_service }} restarted"
+  service: name={{ zabbix_agent_service }}
            state=restarted
   sudo: yes
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,7 +1,7 @@
 ---
 # handlers file for zabbix-agent
 
-- name: "{{ zabbix_agent_service }} restarted"
+- name: restart zabbix-agent
   service: name={{ zabbix_agent_service }}
            state=restarted
   sudo: yes

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -1,49 +1,45 @@
 ---
 # Tasks specific for Debian/Ubuntu Systems
 
-- name: "Debian | Set some facts"
-  set_fact: 
-      zabbix_agent: zabbix-agent
-
 - name: "Debian | Installing deb repository Debian"
   apt_repository: repo="deb http://repo.zabbix.com/zabbix/{{ zabbix_version }}/debian/ {{ ansible_distribution_release }} main" 
                   state=present
-  when: ansible_distribution == "Debian" and zabbix_repo == True
+  when: ansible_distribution == "Debian" and zabbix_repo == "zabbix"
   sudo: yes
 
 - name: "Debian | Installing deb-src repository Debian"
   apt_repository: repo="deb-src http://repo.zabbix.com/zabbix/{{ zabbix_version }}/debian/ {{ ansible_distribution_release }} main" 
                   state=present
-  when: ansible_distribution == "Debian" and zabbix_repo == True
+  when: ansible_distribution == "Debian" and zabbix_repo == "zabbix"
   sudo: yes
 
 - name: "Debian | Installing deb repository Ubuntu"
   apt_repository: repo="deb http://repo.zabbix.com/zabbix/{{ zabbix_version }}/ubuntu/ {{ ansible_distribution_release }} main" 
                   state=present
-  when: ansible_distribution == "Ubuntu" and zabbix_repo == True
+  when: ansible_distribution == "Ubuntu" and zabbix_repo == "zabbix"
   sudo: yes
 
 - name: "Debian | Installing deb-src repository Ubuntu"
   apt_repository: repo="deb-src http://repo.zabbix.com/zabbix/{{ zabbix_version }}/ubuntu/ {{ ansible_distribution_release }} main"
                   state=present
-  when: ansible_distribution == "Ubuntu" and zabbix_repo == True
+  when: ansible_distribution == "Ubuntu" and zabbix_repo == "zabbix"
   sudo: yes
 
 - name: "Debian | Install gpg key"
   apt_key: id=79EA5ED4
            url=http://repo.zabbix.com/zabbix-official-repo.key
-  when: zabbix_repo == True
+  when: zabbix_repo == "zabbix"
   sudo: yes
 
 - name: "Debian | Installing zabbix-agent"
-  apt: pkg=zabbix-agent
+  apt: pkg={{ zabbix_agent_package }}
        state=present 
        update_cache=yes
        cache_valid_time=3600
   sudo: yes
 
 - name: "Debian | Enable the service"
-  service: name={{ zabbix_agent }}
+  service: name={{ zabbix_agent_service }}
            enabled=yes
   sudo: yes
 

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -1,9 +1,19 @@
 ---
 # Tasks specific for RedHat systems
 
-- name: "RedHat | Set some facts"
-  set_fact: 
+- name: "RedHat | Set short version name"
+  set_fact:
+      zabbix_short_version: "{{ zabbix_version | regex_replace('\\.', '') }}"
+
+- name: "RedHat | Use Zabbix package name"
+  set_fact:
       zabbix_agent: zabbix-agent
+  when: zabbix_repo
+
+- name: "RedHat | Use EPEL package name"
+  set_fact:
+      zabbix_agent: "zabbix{{ zabbix_short_version }}-agent"
+  when: not zabbix_repo
 
 - name: "RedHat | Install basic repo file"
   template: src=rhel.repo.j2

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -11,7 +11,7 @@
             owner=root 
             group=root 
             mode=0644
-  when: zabbix_repo == True
+  when: zabbix_repo
   sudo: yes
 
 - name: "RedHat | Installing zabbix-agent"

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -15,12 +15,12 @@
   sudo: yes
 
 - name: "RedHat | Installing zabbix-agent"
-  yum:  pkg=zabbix-agent
+  yum:  pkg={{ zabbix_agent }}
         state=present
   sudo: yes
 
 - name: "RedHat | Enable the service"
-  service: name={{ zabbix_agent }}
+  service: name=zabbix-agent
            enabled=yes
   sudo: yes
 

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -5,15 +5,10 @@
   set_fact:
       zabbix_short_version: "{{ zabbix_version | regex_replace('\\.', '') }}"
 
-- name: "RedHat | Use Zabbix package name"
-  set_fact:
-      zabbix_agent: zabbix-agent
-  when: zabbix_repo
-
 - name: "RedHat | Use EPEL package name"
   set_fact:
-      zabbix_agent: "zabbix{{ zabbix_short_version }}-agent"
-  when: not zabbix_repo
+      zabbix_agent_package: "zabbix{{ zabbix_short_version }}-agent"
+  when: zabbix_repo == "epel"
 
 - name: "RedHat | Install basic repo file"
   template: src=rhel.repo.j2
@@ -21,16 +16,16 @@
             owner=root 
             group=root 
             mode=0644
-  when: zabbix_repo
+  when: zabbix_repo == "zabbix"
   sudo: yes
 
 - name: "RedHat | Installing zabbix-agent"
-  yum:  pkg={{ zabbix_agent }}
+  yum:  pkg={{ zabbix_agent_package }}
         state=present
   sudo: yes
 
 - name: "RedHat | Enable the service"
-  service: name=zabbix-agent
+  service: name={{ zabbix_agent_service }}
            enabled=yes
   sudo: yes
 

--- a/tasks/Suse.yml
+++ b/tasks/Suse.yml
@@ -3,15 +3,15 @@
 
 - name: "Suse | Set some facts"
   set_fact: 
-      zabbix_agent: "zabbix-agentd"
+      zabbix_agent_service: "zabbix-agentd"
 
 - name: "Suse | Install basic repo file"
   zypper_repository: repo="http://download.opensuse.org/repositories/server:monitoring/openSUSE_{{ ansible_distribution_version }}/server:monitoring.repo"
-  when: zabbix_repo == True
+  when: zabbix_repo == "zabbix"
   sudo: yes
 
 - name: "Suse | Install zabbix-agent"
-  zypper: name=zabbix-agent
+  zypper: name={{ zabbix_agent_package }}
           state=present
           disable_gpg_check=yes
   sudo: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,7 +19,7 @@
             owner=zabbix 
             group=zabbix
             mode=0755 
-  notify: "{{ zabbix_agent_service }} restarted"
+  notify: restart zabbix-agent
   sudo: yes
 
 - name: "Create include dir zabbix-agent"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,7 +19,7 @@
             owner=zabbix 
             group=zabbix
             mode=0755 
-  notify: "{{ zabbix_agent }} restarted"
+  notify: "{{ zabbix_agent_service }} restarted"
   sudo: yes
 
 - name: "Create include dir zabbix-agent"

--- a/tasks/userparameter.yml
+++ b/tasks/userparameter.yml
@@ -6,6 +6,6 @@
         owner=zabbix
         group=zabbix
         mode=0755
-  notify: "{{ zabbix_agent }} restarted"
+  notify: "{{ zabbix_agent_service }} restarted"
   sudo: yes
 

--- a/tasks/userparameter.yml
+++ b/tasks/userparameter.yml
@@ -6,6 +6,6 @@
         owner=zabbix
         group=zabbix
         mode=0755
-  notify: "{{ zabbix_agent_service }} restarted"
+  notify: restart zabbix-agent
   sudo: yes
 


### PR DESCRIPTION
CentOS / RHEL (EPEL) embed the version number in the package name unlike Zabbix.com.

i.e. _zabbix22-agent_ versus _zabbix-agent_

**Zabbix.com:**
- http://repo.zabbix.com/zabbix/2.2/rhel/6/x86_64/zabbix-agent-2.2.10-1.el6.x86_64.rpm

**EPEL:**
- https://dl.fedoraproject.org/pub/epel/6/x86_64/zabbix22-agent-2.2.1-5.el6.x86_64.rpm

This change derives a _short version_ from the _zabbix_version_ var and constructs the _zabbix_agent_ var appropriately.