### PR TITLE
set cache_valid_time=0 to ensure an apt-get update after the added repo-key

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -57,7 +57,11 @@
   apt: pkg={{ zabbix_agent_package }}
        state=present 
        update_cache=yes
-       cache_valid_time=3600
+       cache_valid_time=0
+       # Note: set cache_valid_time=0 to ensure that an apt-get update after the added repo-key
+       # else you often get 'WARNING: The following packages cannot be authenticated!
+       # See also: http://askubuntu.com/questions/75565/why-am-i-getting-authentication-errors-for-packages-from-an-ubuntu-repository
+
   sudo: yes
   tags:
     - zabbix-agent


### PR DESCRIPTION
I set cache_valid_time=0 to ensure that an apt-get update after the added repo-key
else you often get 'WARNING: The following packages cannot be authenticated!
See also: http://askubuntu.com/questions/75565/why-am-i-getting-authentication-errors-for-packages-from-an-ubuntu-repository

ps: following might be related ansible issue: https://github.com/ansible/ansible-modules-core/issues/1497
I'm running currently with ansible v1.9.2 (on Mac, installed using brew)

and following role issue might have the same cause:
https://github.com/dj-wasabi/ansible-zabbix-agent/issues/21