### PR TITLE
specified become for local tasks

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -106,6 +106,7 @@
     host_group: "{{ zabbix_host_groups }}"
     state: "{{ zabbix_create_hostgroup }}"
   when: zabbix_api_use
+  become: no
   tags:
     - api
 
@@ -128,6 +129,7 @@
         dns: "{{ ansible_fqdn }}"
         port: "{{ agent_listenport }}"
   when: zabbix_api_use
+  become: no
   tags:
     - api
 
@@ -142,5 +144,6 @@
     macro_value: "{{ item.macro_value }}"
   with_items: zabbix_macros
   when: zabbix_api_use and zabbix_macros is defined and item.macro_key is defined
+  become: no
   tags:
     - api


### PR DESCRIPTION
We use non-privileged user for remote connections and have to use `become: yes` as a default param for our playbooks. So we would like to disable `become` for local tasks.