### PR TITLE
add proxy param to zabbix api

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,6 +16,7 @@ zabbix_api_pass: zabbix
 zabbix_create_hostgroup: present  # or absent
 zabbix_create_host: present       # or absent
 zabbix_host_status: enabled       # or disabled
+zabbix_proxy: null
 zabbix_useuip: 1
 zabbix_host_groups:
   - Linux Servers

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -120,6 +120,7 @@
     link_templates: "{{ zabbix_link_templates }}"
     status: "{{ zabbix_host_status }}"
     state: "{{ zabbix_create_host }}"
+    proxy: "{{ zabbix_proxy }}"
     interfaces:
       - type: 1
         main: 1


### PR DESCRIPTION
Add `proxy` parameter for `zabbix_host` module