### PR TITLE
New molecule setup; updated changelog

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,11 @@ before_install:
 - sudo apt-get install -o Dpkg::Options::="--force-confold" --force-yes -y docker-engine
 
 install:
-- pip install molecule
+- pip install molecule ansible
 
 script:
+- molecule --version
+- ansible --version
 - molecule test
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,14 @@ Below an overview of all changes in the releases.
 
 Version (Release date)
 
-0.8.0   (2016-)
+0.8.0   (2016-08-24)
 
   * Added more tests for Molecule
   * Configured Travis to execute the Molecule tests
   * specified become for local tasks #33 (By pull request: kam1kaze (Thanks!))
   * add proxy param to zabbix api #34 (By pull request: kam1kaze (Thanks!))
+  * Fix for: zabbix 3 JMX interface Added property `agent_interfaces` to configure the interfaces via the API.
+  * Fix for: skip zabbix_group module (Replaced `zabbix_api_use` by the properties `zabbix_api_create_hostgroup` and `zabbix_api_create_hosts`)
 
 0.7.0   (2016-07-11)
 

--- a/README.md
+++ b/README.md
@@ -278,6 +278,14 @@ and in the playbook only specifying:
 #Molecule
 
 This roles is configured to be tested with Molecule. You can find on this page some more information regarding Molecule: https://werner-dijkerman.nl/2016/07/10/testing-ansible-roles-with-molecule-testinfra-and-docker/
+Molecule will boot 3 docker containers, containing the following OS:
+
+* Debian 8
+* CentOS 7
+* Ubuntu 14.04
+
+On these containers, this Ansible role is executed. After this, a idempotence check is run.
+When all is executed correctly, TestInfra is executed to validate the installation/configuration.
 
 #Extra Information
 

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -1,4 +1,8 @@
+from testinfra.utils.ansible_runner import AnsibleRunner
 import pytest
+
+testinfra_hosts = AnsibleRunner('.molecule/ansible_inventory').get_hosts('all')
+
 
 def test_zabbixagent_running_and_enabled(Service, SystemInfo):
     zabbixagent = Service("zabbix-agent")


### PR DESCRIPTION
With molecule 1.9.x, the testinfra tests has some extra code in the test_*.py file.