### PR TITLE
Set everything the same with agent_hostname

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,7 +44,7 @@ agent_listenport: 10050
 agent_listeninterface:
 agent_listenip:
 agent_startagents: 3
-agent_hostname:
+agent_hostname: "{{ inventory_hostname }}"
 agent_hostnameitem:
 agent_hostmetadata:
 agent_hostmetadataitem:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -117,7 +117,7 @@
     server_url: "{{ zabbix_url }}"
     login_user: "{{ zabbix_api_user }}"
     login_password: "{{ zabbix_api_pass }}"
-    host_name: "{{ ansible_fqdn }}"
+    host_name: "{{ agent_hostname }}"
     host_groups: "{{ zabbix_host_groups }}"
     link_templates: "{{ zabbix_link_templates }}"
     status: "{{ zabbix_host_status }}"

--- a/templates/zabbix_agentd.conf.j2
+++ b/templates/zabbix_agentd.conf.j2
@@ -99,7 +99,9 @@ ServerActive={{ agent_serveractive }}
 #       required for active checks and must match hostname as configured on the server.
 #       value is acquired from hostnameitem if undefined.
 #
-Hostname={{ inventory_hostname }}
+{% if agent_hostname is defined and agent_hostname %}
+Hostname={{ agent_hostname }}
+{% endif %}
 
 ### option: hostnameitem
 #       item used for generating hostname if it is undefined.


### PR DESCRIPTION
Hostname in template is the same as the one via the zabbix_host module, configured via `agent_hostname`.