### PR TITLE
Fix missed tag

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,8 @@
 
 - name: "Include OS-specific variables"
   include_vars: "{{ ansible_os_family }}.yml"
+  tags:
+    - zabbix-agent
 
 - name: "Install the correct repository"
   include: "RedHat.yml"


### PR DESCRIPTION
Error:
```
TASK [dj-wasabi.zabbix-agent : Debian | Enable the service] ********************
fatal: [linux-buildagent-10]: FAILED! => {"failed": true, "msg": "'zabbix_agent_service' is undefined"}
```

Command:
```
$ ansible-playbook -i inventory/production linux.yml -t zabbix-agent -K
```