### PR TITLE
Fix hostname mistmatch when updating macros

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -137,7 +137,7 @@
     server_url: "{{ zabbix_url }}"
     login_user: "{{ zabbix_api_user }}"
     login_password: "{{ zabbix_api_pass }}"
-    host_name: "{{ ansible_fqdn }}"
+    host_name: "{{ inventory_hostname }}"
     macro_name: "{{ item.macro_key }}"
     macro_value: "{{ item.macro_value }}"
   with_items: "{{ zabbix_macros | default([]) }}"


### PR DESCRIPTION
Use `inventory_hostname` instead of `ansible_fqdn`.