### PR TITLE
Debian squeeze

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -9,49 +9,54 @@
       zabbix_short_version: "{{ zabbix_version | regex_replace('\\.', '') }}"
 
 - name: "Debian | Installing deb repository Debian"
-  apt_repository: repo="deb http://repo.zabbix.com/zabbix/{{ zabbix_version }}/debian/ {{ ansible_distribution_release }} main"
+  apt_repository: repo="deb http://repo.zabbix.com/zabbix/{{ zabbix_version }}/debian/ {{ ansible_lsb.codename }} main"
                   state=present
   when: ansible_distribution == "Debian" and zabbix_repo == "zabbix"
   become: yes
   tags:
     - zabbix-agent
     - init
+    - repository
 
 - name: "Debian | Installing deb-src repository Debian"
-  apt_repository: repo="deb-src http://repo.zabbix.com/zabbix/{{ zabbix_version }}/debian/ {{ ansible_distribution_release }} main"
+  apt_repository: repo="deb-src http://repo.zabbix.com/zabbix/{{ zabbix_version }}/debian/ {{ ansible_lsb.codename }} main"
                   state=present
   when: ansible_distribution == "Debian" and zabbix_repo == "zabbix"
   become: yes
   tags:
     - zabbix-agent
     - init
+    - repository
 
 - name: "Debian | Installing deb repository Ubuntu"
-  apt_repository: repo="deb http://repo.zabbix.com/zabbix/{{ zabbix_version }}/ubuntu/ {{ ansible_distribution_release }} main"
+  apt_repository: repo="deb http://repo.zabbix.com/zabbix/{{ zabbix_version }}/ubuntu/ {{ ansible_lsb.codename }} main"
                   state=present
   when: ansible_distribution == "Ubuntu" and zabbix_repo == "zabbix"
   become: yes
   tags:
     - zabbix-agent
     - init
+    - repository
 
 - name: "Debian | Installing deb-src repository Ubuntu"
-  apt_repository: repo="deb-src http://repo.zabbix.com/zabbix/{{ zabbix_version }}/ubuntu/ {{ ansible_distribution_release }} main"
+  apt_repository: repo="deb-src http://repo.zabbix.com/zabbix/{{ zabbix_version }}/ubuntu/ {{ ansible_lsb.codename }} main"
                   state=present
   when: ansible_distribution == "Ubuntu" and zabbix_repo == "zabbix"
   become: yes
   tags:
     - zabbix-agent
     - init
+    - repository
 
 - name: "Debian | Install gpg key"
-  apt_key: id="{{ sign_keys[zabbix_short_version][ansible_distribution_release]['sign_key'] }}"
+  apt_key: id="{{ sign_keys[zabbix_short_version][ansible_lsb.codename]['sign_key'] }}"
            url=http://repo.zabbix.com/zabbix-official-repo.key
   when: zabbix_repo == "zabbix"
   become: yes
   tags:
     - zabbix-agent
     - init
+    - key
 
 - name: "Debian | Installing zabbix-agent"
   apt: pkg={{ zabbix_agent_package }}
@@ -66,6 +71,7 @@
   tags:
     - zabbix-agent
     - init
+    - package
 
 - name: "Debian | Enable the service"
   service: name={{ zabbix_agent_service }}

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -8,6 +8,16 @@
   set_fact:
       zabbix_short_version: "{{ zabbix_version | regex_replace('\\.', '') }}"
 
+- name: "Debian | Installing lsb support"
+  apt: pkg=lsb-release
+       state=present
+  when: ansible_distribution == "Debian" and zabbix_repo == "zabbix"
+  become: yes
+  tags:
+    - zabbix-agent
+    - init
+    - repository
+
 - name: "Debian | Installing deb repository Debian"
   apt_repository: repo="deb http://repo.zabbix.com/zabbix/{{ zabbix_version }}/debian/ {{ ansible_lsb.codename }} main"
                   state=present

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -9,9 +9,12 @@
       zabbix_short_version: "{{ zabbix_version | regex_replace('\\.', '') }}"
 
 - name: "Debian | Installing lsb support"
-  apt: pkg=lsb-release
+  apt: pkg={{ item }}
        state=present
   when: ansible_distribution == "Debian" and zabbix_repo == "zabbix"
+  with_items:
+  - lsb-release
+  - lsb-base
   become: yes
   tags:
     - zabbix-agent

--- a/vars/zabbix.yml
+++ b/vars/zabbix.yml
@@ -3,11 +3,11 @@
 sign_keys:
   "32":
     wheezy:
-      sign_key: 79EA5ED4
+      sign_key: E709712C
     jessie:
-      sign_key: 79EA5ED4
+      sign_key: E709712C
     trusty:
-      sign_key: 79EA5ED4
+      sign_key: E709712C
     xenial:
       sign_key: E709712C
   "30":
@@ -30,6 +30,8 @@ sign_keys:
       sign_key: 79EA5ED4
   "22":
     squeeze:
+      sign_key: 79EA5ED4
+    wheezy:
       sign_key: 79EA5ED4
     jessie:
       sign_key: 79EA5ED4


### PR DESCRIPTION
The fact "ansible_distribution_release" return "NA" for Debian Squeeze with break the apt database. 

The best solution I found was change this for another fact. "ansible_lsb.codename" is OK, returning "squeeze", like expected.

Testing in others versions was OK in dozens servers, too.