### PR TITLE
get gpg key over https

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -46,7 +46,7 @@
 
 - name: "Debian | Install gpg key"
   apt_key: id="{{ sign_keys[zabbix_short_version][ansible_distribution_release]['sign_key'] }}"
-           url=http://repo.zabbix.com/zabbix-official-repo.key
+           url=https://repo.zabbix.com/zabbix-official-repo.key
   when: zabbix_repo == "zabbix"
   become: yes
   tags:


### PR DESCRIPTION
I've been running into the following fatal when using this role (release 0.9.0);

````
TASK [dj-wasabi.zabbix : Debian | Install gpg key] *****************************
fatal: [vagrant]: FAILED! => {"changed": false, "failed": true, "msg": "error getting key id from url: http://repo.zabbix.com/zabbix-official-repo.key", "traceback": "Traceback (most recent call last):\n  File \"/tmp/ansible_svmYxP/ansible_module_apt_key.py\", line 209, in download_key\n    return rsp.read()\n  File \"/usr/lib/python2.7/socket.py\", line 351, in read\n    data = self._sock.recv(rbufsize)\n  File \"/usr/lib/python2.7/httplib.py\", line 573, in read\n    s = self.fp.read(amt)\n  File \"/usr/lib/python2.7/socket.py\", line 380, in read\n    data = self._sock.recv(left)\nerror: [Errno 104] Connection reset by peer\n"}
````

This is resolved by getting the gpg key over https rather then http.