### PR TITLE
zabbix_hostmacro fix

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -143,7 +143,7 @@
     server_url: "{{ zabbix_url }}"
     login_user: "{{ zabbix_api_user }}"
     login_password: "{{ zabbix_api_pass }}"
-    host_name: "{{ inventory_hostname }}"
+    host_name: "{{ agent_hostname }}"
     macro_name: "{{ item.macro_key }}"
     macro_value: "{{ item.macro_value }}"
   with_items: "{{ zabbix_macros | default([]) }}"


### PR DESCRIPTION
Updating host configuration with macros should use agent_hostname as hostname to be consistent