### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Table of Contents
 8. [License](#license)
 9. [Author Information](#author-information)
 
-#Overview
+# Overview
 
 Build Status:
 
@@ -40,8 +40,8 @@ This is one of the 'dj-wasabi' roles which configures your whole zabbix environm
 
 As of version 0.8.0, the property `zabbix_api_use` isn't available anymore. It is replaced by the properties `zabbix_api_create_hostgroup` and `zabbix_api_create_hosts`
 
-#Requirements
-##Operating systems
+# Requirements
+## Operating systems
 This role will work on the following operating systems:
 
  * Red Hat
@@ -52,7 +52,7 @@ This role will work on the following operating systems:
 So, you'll need one of those operating systems.. :-)
 Please sent Pull Requests or suggestions when you want to use this role for other Operating systems.
 
-##Zabbix Versions
+## Zabbix Versions
 
 See the following list of supported Operating systems with the Zabbix releases:
 
@@ -104,11 +104,11 @@ You can install this locally with the following command: `pip install zabbix-api
 
 This ansible role uses the modules from "Cove" found in this pull request: https://github.com/ansible/ansible-modules-extras/pull/44. So all credits goes to this guy!
 
-#Installation
+# Installation
 
 Installing this role is very simple: `ansible-galaxy install dj-wasabi.zabbix-agent`
 
-#Role Variables
+# Role Variables
 
 ## Main variables
 There are some variables in de default/main.yml which can (Or needs to) be changed/overriden:
@@ -194,11 +194,11 @@ These variables needs to be changed/overriden when you want to make use of the z
 * `zabbix_macros`: An list with macro_key and macro_value for creating hostmacro's.
 
 
-#Dependencies
+# Dependencies
 
 There are no dependencies on other roles.
 
-#Example Playbook
+# Example Playbook
 
 ## agent_interfaces
 
@@ -238,7 +238,7 @@ agent_interfaces:
     port: "{{ agent_listenport }}"
 ```
 
-##Vars in role configuration 
+## Vars in role configuration 
 Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
 
     - hosts: all
@@ -260,7 +260,7 @@ Including an example of how to use your role (for instance, with variables passe
              - macro_key: apache_type
                macro_value: reverse_proxy
 
-##Combination of group_vars and playbook 
+## Combination of group_vars and playbook 
 You can also use the group_vars or the host_vars files for setting the variables needed for this role. File you should change: `group_vars/all` or `host_vars/<zabbix_server>` (Where <zabbix_server> is the hostname of the machine running Zabbix Server)
 
 		agent_server: 192.168.33.30
@@ -285,7 +285,7 @@ and in the playbook only specifying:
       roles:
          - role: dj-wasabi.zabbix-agent
 
-#Molecule
+# Molecule
 
 This roles is configured to be tested with Molecule. You can find on this page some more information regarding Molecule: https://werner-dijkerman.nl/2016/07/10/testing-ansible-roles-with-molecule-testinfra-and-docker/
 Molecule will boot 3 docker containers, containing the following OS:
@@ -297,7 +297,7 @@ Molecule will boot 3 docker containers, containing the following OS:
 On these containers, this Ansible role is executed. After this, a idempotence check is run.
 When all is executed correctly, TestInfra is executed to validate the installation/configuration.
 
-#Extra Information
+# Extra Information
 
 You can install so-called userparameter files by adding the following into your roles:
 
@@ -321,11 +321,11 @@ You can extend your zabbix configuration by adding items yourself that do specif
 
 (Maybe in near future doing it with variables.)
 
-#License
+# License
 
 GPLv3
 
-#Author Information
+# Author Information
 
 Please send suggestion or pull requests to make this role better. Also let me know if you encouter any issues installing or using this role.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
