### PR TITLE
Added run_once to only execute the task once

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -121,6 +121,7 @@
     host_group: "{{ zabbix_host_groups }}"
     state: "{{ zabbix_create_hostgroup }}"
   when: zabbix_api_create_hostgroup
+  run_once: True
   become: no
   tags:
     - api


### PR DESCRIPTION
Possible fix for: Create hostgroups task not working as intended #71