### PR TITLE
Fix zabbix_version string comparison

### DIFF
--- a/templates/zabbix_agentd.conf.j2
+++ b/templates/zabbix_agentd.conf.j2
@@ -207,7 +207,7 @@ UnsafeUserParameters={{ agent_unsafeuserparameters }}
 # disabled. an configuration file should be placed on directory: {{ agent_include }}
 
 ####### LOADABLE MODULES #######
-{% if zabbix_version == '2.2' or zabbix_version == '2.4' or zabbix_version == '3.0' %}
+{% if zabbix_version | version_compare('2.2', '>=') %}
 ### Option: LoadModulePath
 #       Full path to location of agent modules.
 #       Default depends on compilation options.
@@ -225,7 +225,7 @@ LoadModulePath={{ agent_loadmodulepath }}
 LoadModule={{ agent_loadmodule }}
 {% endif %}
 
-{% if zabbix_version == '3.0' %}
+{% if zabbix_version | version_compare('3.0', '>=') %}
 ####### TLS-RELATED PARAMETERS #######
 
 ### Option: TLSConnect


### PR DESCRIPTION
Comparisons with '==' operator did not work for me - replaced them with more fitting version_compare jinja2 test.