### PR TITLE
Add creation of PSK file

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,8 @@ These variables are specific for Zabbix 3.0/
 
 * `agent_tlspskfile`: Full pathname of a file containing the pre-shared key.
 
+* `zabbix_agent_tlspsk_secret`: The pre-shared secret key that should be placed in the file configured with `agent_tlspskfile`.
+
 ## Zabbix API variables
 These variables needs to be changed/overriden when you want to make use of the zabbix-api for automatically creating and or updating hosts.
 
@@ -294,7 +296,9 @@ Molecule will boot 3 docker containers, containing the following OS:
 
 * Debian 8
 * CentOS 7
-* Ubuntu 14.04
+* Ubuntu 16.04
+* Mint
+* OpenSuse
 
 On these containers, this Ansible role is executed. After this, a idempotence check is run.
 When all is executed correctly, TestInfra is executed to validate the installation/configuration.

--- a/molecule.yml
+++ b/molecule.yml
@@ -58,7 +58,6 @@ docker:
       docker: container
     volume_mounts:
       - "/sys/fs/cgroup:/sys/fs/cgroup:ro"
-#    command: /bin/systemd
 
 verifier:
   name: testinfra

--- a/playbook.yml
+++ b/playbook.yml
@@ -28,3 +28,8 @@
       zabbix_agent_server: 192.168.3.33
       zabbix_agent_serveractive: 192.168.3.33
       zabbix_agent_listenip: 0.0.0.0
+      zabbix_agent_tlsconnect: psk
+      zabbix_agent_tlsaccept: psk
+      zabbix_agent_tlspskidentity: my_Identity
+      zabbix_agent_tlspskfile: /data/certs/zabbix.psk
+      zabbix_agent_tlspsk_secret: 97defd6bd126d5ba7fa5f296595f82eac905d5eda270207a580ab7c0cb9e8eab

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 160

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -112,6 +112,28 @@
     - config
     - init
 
+- name: "Create directory for PSK file if not exist."
+  file:
+    path: "{{ zabbix_agent_tlspskfile | dirname }}"
+    mode: 0755
+    state: directory
+  when:
+    - zabbix_agent_tlspskfile is defined
+    - zabbix_agent_tlspskfile != ''
+
+- name: "Place TLS PSK File"
+  copy:
+    dest: "{{ zabbix_agent_tlspskfile }}"
+    content: "{{ zabbix_agent_tlspsk_secret }}"
+    owner: zabbix
+    group: zabbix
+    mode: 0400
+  when:
+    - zabbix_agent_tlspskfile is defined
+    - zabbix_agent_tlspsk_secret is defined
+    - zabbix_agent_tlspskfile != ''
+    - zabbix_agent_tlspsk_secret != ''
+
 - name: "Create include dir zabbix-agent"
   file:
     path: "{{ zabbix_agent_include }}"

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -24,7 +24,17 @@ def test_zabbix_agent_dot_conf(File, SystemInfo):
     assert passwd.contains("ServerActive=192.168.3.33")
     assert passwd.contains("ListenIP=0.0.0.0")
     assert passwd.contains("DebugLevel=3")
-    assert passwd.contains("# TLSAccept=unencrypted")
+    assert passwd.contains("TLSAccept=psk")
+    assert passwd.contains("TLSPSKIdentity=my_Identity")
+    assert passwd.contains("TLSPSKFile=/data/certs/zabbix.psk")
+
+
+def test_zabbix_agent_psk(File):
+    psk_file = File("/data/certs/zabbix.psk")
+    assert psk_file.user == "zabbix"
+    assert psk_file.group == "zabbix"
+    assert psk_file.mode == 0o400
+    assert psk_file.contains("97defd6bd126d5ba7fa5f296595f82eac905d5eda270207a580ab7c0cb9e8eab")
 
 
 def test_zabbix_include_dir(File):


### PR DESCRIPTION
A fix for: PSK in variable #83

When both `zabbix_agent_tlspskfile` and `zabbix_agent_tlspsk_secret` are configured, the file will be created.