### PR TITLE
Do not report as change when update an existing host's info

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -195,6 +195,7 @@
   when:
     - zabbix_api_create_hosts
   become: no
+  changed_when: false
   tags:
     - api
 


### PR DESCRIPTION
I would prefer not see "changed = 1" at each playbook run