### PR TITLE
Delete option "run_once" from task "Create hostgroups"

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -179,7 +179,6 @@
     state: "{{ zabbix_create_hostgroup }}"
   when:
     - zabbix_api_create_hostgroup
-#  run_once: True
   become: no
   tags:
     - api

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -173,7 +173,7 @@
     state: "{{ zabbix_create_hostgroup }}"
   when:
     - zabbix_api_create_hostgroup
-  run_once: True
+#  run_once: True
   become: no
   tags:
     - api


### PR DESCRIPTION
 Delete option "run_once" from task "Create hostgroups", for deploy agents with dynamic generate zabbix_host_groups variable (groups per agent). 
