### PR TITLE
allow 127.0.0.1 for listenip

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -60,6 +60,7 @@
     msg: "The specified network interface does not exist"
   when:
     - zabbix_agent_listeninterface
+    - zabbix_agent_listenip != '127.0.0.1'
     - (zabbix_agent_listeninterface not in ansible_all_ipv4_addresses)
   tags:
     - zabbix-agent

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -60,7 +60,6 @@
     msg: "The specified network interface does not exist"
   when:
     - zabbix_agent_listeninterface
-    - zabbix_agent_listenip != '127.0.0.1'
     - (zabbix_agent_listeninterface not in ansible_all_ipv4_addresses)
   tags:
     - zabbix-agent
@@ -92,6 +91,7 @@
     msg: "The agent_listenip does not exist"
   when:
     - zabbix_agent_listenip != '0.0.0.0'
+    - zabbix_agent_listenip != '127.0.0.1'
     - (zabbix_agent_listenip not in ansible_all_ipv4_addresses)
   tags:
     - zabbix-agent


### PR DESCRIPTION
Allows 127.0.0.1 for the agent to run on which is not in ansible_all_ipv4_addresses