### PR TITLE
Replaced `yum` with `package`

### DIFF
--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -33,7 +33,7 @@
     - skip_ansible_lint
 
 - name: "RedHat | Installing zabbix-agent"
-  yum:
+  package:
     pkg: "{{ item }}"
     state: "{{ zabbix_agent_package_state }}"
   become: yes
@@ -43,7 +43,7 @@
     - zabbix-agent
 
 - name: "Install policycoreutils-python"
-  yum:
+  package:
     name: policycoreutils-python
     state: installed
   when: zabbix_selinux


### PR DESCRIPTION
This allows `package` to use whatever package manager is installed on the system, instead of limiting it to only `yum` (for example we're using dnf on redhat).   

If merged, can you please release new version to Ansible Galaxy soonest?