### PR TITLE
Added gpg key id for agent version 3.0 in Debian Stretch

### DIFF
--- a/vars/zabbix.yml
+++ b/vars/zabbix.yml
@@ -36,6 +36,8 @@ sign_keys:
       sign_key: 79EA5ED4
     jessie:
       sign_key: 79EA5ED4
+    stretch:
+      sign_key: A14FE591
     trusty:
       sign_key: 79EA5ED4
     xenial:


### PR DESCRIPTION
Small addition, v3.0 still can be used in some cases.