### PR TITLE
fixes for the userparameter task

### DIFF
--- a/tasks/userparameter.yml
+++ b/tasks/userparameter.yml
@@ -6,6 +6,6 @@
     dest: "{{ zabbix_agent_include }}/mysql.conf"
     owner: zabbix
     group: zabbix
-    mode: 0755
+    mode: 0644
   notify: restart zabbix-agent
   become: yes

--- a/tasks/userparameter.yml
+++ b/tasks/userparameter.yml
@@ -3,7 +3,7 @@
 - name: "Installing sample file"
   copy:
     src: sample.conf
-    dest: "{{ agent_include }}/mysql.conf"
+    dest: "{{ zabbix_agent_include }}/mysql.conf"
     owner: zabbix
     group: zabbix
     mode: 0755


### PR DESCRIPTION
* agent_include  renamed to zabbix_agent_include
* access mode lowered from 755 to 644, as the configs files didn't suppose to have exec permissions