### PR TITLE
Added fix for: Host autoregistered in zabbix with IP 0.0.0.0 when Lis…

### DIFF
--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -26,7 +26,6 @@ def test_zabbix_agent_dot_conf(File, SystemInfo):
 
     assert passwd.contains("Server=192.168.3.33")
     assert passwd.contains("ServerActive=192.168.3.33")
-    assert passwd.contains("ListenIP=0.0.0.0")
     assert passwd.contains("DebugLevel=3")
     assert passwd.contains("TLSAccept=psk")
     assert passwd.contains("TLSPSKIdentity=my_Identity")

--- a/templates/zabbix_agentd.conf.j2
+++ b/templates/zabbix_agentd.conf.j2
@@ -76,7 +76,9 @@ ListenPort={{ zabbix_agent_listenport }}
 #       list of comma delimited ip addresses that the agent should listen on.
 #       first ip address is sent to zabbix server if connecting to it to retrieve list of active checks.
 #
+{% if zabbix_agent_listenip !='0.0.0.0' %}
 ListenIP={{ zabbix_agent_listenip }}
+{% endif %}
 
 ### option: startagents
 #       number of pre-forked instances of zabbix_agentd that process passive checks.


### PR DESCRIPTION
This PR contains a fix for https://github.com/dj-wasabi/ansible-zabbix-server/issues/84