### PR TITLE
Use zabbix api to add psk settings to the host entry. Need minimum ansible 2.5

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,6 +36,7 @@ zabbix_api_create_hosts: False
 zabbix_create_hostgroup: present  # or absent
 zabbix_create_host: present       # or absent
 zabbix_host_status: enabled       # or disabled
+zabbix_host_description:
 zabbix_proxy: null
 zabbix_inventory_mode: disabled
 zabbix_useuip: 1

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -229,6 +229,7 @@
     tls_psk: "{{ zabbix_agent_tlspsk_secret if (zabbix_agent_tlsaccept == 'psk') else '' }}"
     tls_issuer: "{{ zabbix_agent_tlsservercertissuer if (zabbix_agent_tlsaccept == 'cert') else '' }}"
     tls_subject: "{{ zabbix_agent_tlsservercertsubject if (zabbix_agent_tlsaccept == 'cert') else '' }}"
+    description: "{{ zabbix_host_description }}"
   when:
     - zabbix_api_create_hosts
   become: no

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -223,6 +223,12 @@
     inventory_mode: "{{ zabbix_inventory_mode }}"
     interfaces: "{{ zabbix_agent_interfaces }}"
     visible_name: "{{ zabbix_visible_hostname|default(zabbix_agent_hostname) }}"
+    tls_accept: "{{ {'unencrypted': '1', 'psk': '2', 'cert' : '4'}[zabbix_agent_tlsaccept] | default('1') }}"
+    tls_connect: "{{ {'unencrypted': '1', 'psk': '2', 'cert' : '4'}[zabbix_agent_tlsconnect] | default('1') }}"
+    tls_psk_identity: "{{ zabbix_agent_tlspskidentity if (zabbix_agent_tlsaccept == 'psk') else '' }}"
+    tls_psk: "{{ zabbix_agent_tlspsk_secret if (zabbix_agent_tlsaccept == 'psk') else '' }}"
+    tls_issuer: "{{ zabbix_agent_tlsservercertissuer if (zabbix_agent_tlsaccept == 'cert') else '' }}"
+    tls_subject: "{{ zabbix_agent_tlsservercertsubject if (zabbix_agent_tlsaccept == 'cert') else '' }}"
   when:
     - zabbix_api_create_hosts
   become: no


### PR DESCRIPTION

**Description of PR**
Old zabbix api overwrites Encription settings with "No encryption" if ansible module have not got set of encryption variables.
Ansible 2.5 now have tls_* variables for module zabbix_host, which can set kind of encrition.

**Type of change**
Feature Pull Request
Bugfix Pull Request

**Fixes an issue**
There is no issue that fixed.