### PR TITLE
Add configuration to prevent host updating via zabbix api

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,8 @@ These variables needs to be changed/overriden when you want to make use of the z
 
 * `zabbix_create_host`: present (Default) if the host needs to be created or absent is you want to delete it. This only works when `zabbix_api_create_hosts` is set to `True`.
 
+* `zabbix_update_host`: yes (Default) if the host should be updated if already present. This only works when `zabbix_api_create_hosts` is set to `True`.
+
 * `zabbix_useuip`: 1 if connection to zabbix-agent is made via ip, 0 for fqdn.
 
 * `zabbix_host_groups`: An list of hostgroups which this host belongs to.
@@ -226,7 +228,7 @@ These variables needs to be changed/overriden when you want to make use of the z
 * `zabbix_inventory_mode`: Configure Zabbix inventory mode. Needed for building inventory data, manually when configuring a host or automatically by using some automatic population options. This has to be set to `automatic` if you want to make automatically building inventory data.
 
 * `zabbix_visible_hostname` : Configure Zabbix visible name inside zabbix web UI for the node.
-     
+
 ## Other variables
 
 * `zabbix_agent_firewall_enable`: If IPtables needs to be updated by opening an TCP port for port configured in `zabbix_agent_listenport`.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,6 +35,7 @@ zabbix_api_create_hostgroup: False
 zabbix_api_create_hosts: False
 zabbix_create_hostgroup: present  # or absent
 zabbix_create_host: present       # or absent
+zabbix_update_host: yes
 zabbix_host_status: enabled       # or disabled
 zabbix_proxy: null
 zabbix_inventory_mode: disabled

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -219,6 +219,7 @@
     link_templates: "{{ zabbix_link_templates }}"
     status: "{{ zabbix_host_status }}"
     state: "{{ zabbix_create_host }}"
+    force: "{{ zabbix_update_host }}"
     proxy: "{{ zabbix_proxy }}"
     inventory_mode: "{{ zabbix_inventory_mode }}"
     interfaces: "{{ zabbix_agent_interfaces }}"


### PR DESCRIPTION
**Description of PR**

This PR adds a new configuration option `zabbix_update_host` to control if the host should be updated when it already exists in zabbix server. The default value is `yes` (current behaviour). If you set it to `no`, the host will not be updated in your zabbix server if it already exist.

**Type of change**

Feature Pull Request
