### PR TITLE
implement zabbix host configuration for tls psk encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,16 @@ and in the playbook only specifying:
       roles:
          - role: dj-wasabi.zabbix-agent
 
+
+## Example for TLS PSK encrypted agent communication
+Variables e.g. in the playbook or in `host_vars/myhost`:
+
+    zabbix_agent_tlsaccept: psk
+    zabbix_agent_tlsconnect: psk
+    zabbix_agent_tlspskidentity: "myhost PSK"
+    zabbix_agent_tlspsk_secret: b7e3d380b9d400676d47198ecf3592ccd4795a59668aa2ade29f0003abbbd40d
+    zabbix_agent_tlspskfile: /etc/zabbix/zabbix_agent_pskfile.psk
+
 # Molecule
 
 This roles is configured to be tested with Molecule. You can find on this page some more information regarding Molecule: https://werner-dijkerman.nl/2016/07/10/testing-ansible-roles-with-molecule-testinfra-and-docker/

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -84,13 +84,14 @@ zabbix_agent_loadmodulepath: ${libdir}/modules
 zabbix_agent_loadmodule:
 
 # TLS settings
-zabbix_agent_tlsconnect:
-zabbix_agent_tlsaccept:
+#zabbix_agent_tlsconnect:
+#zabbix_agent_tlsaccept:
 zabbix_agent_tlscafile:
 zabbix_agent_tlscrlfile:
 zabbix_agent_tlsservercertissuer:
 zabbix_agent_tlsservercertsubject:
 zabbix_agent_tlscertfile:
 zabbix_agent_tlskeyfile:
-zabbix_agent_tlspskidentity:
-zabbix_agent_tlspskfile: ''
+#zabbix_agent_tlspskidentity:
+#zabbix_agent_tlspsk_secret
+#zabbix_agent_tlspskfile: ''

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -84,14 +84,14 @@ zabbix_agent_loadmodulepath: ${libdir}/modules
 zabbix_agent_loadmodule:
 
 # TLS settings
-#zabbix_agent_tlsconnect:
-#zabbix_agent_tlsaccept:
+# zabbix_agent_tlsconnect:
+# zabbix_agent_tlsaccept:
 zabbix_agent_tlscafile:
 zabbix_agent_tlscrlfile:
 zabbix_agent_tlsservercertissuer:
 zabbix_agent_tlsservercertsubject:
 zabbix_agent_tlscertfile:
 zabbix_agent_tlskeyfile:
-#zabbix_agent_tlspskidentity:
-#zabbix_agent_tlspsk_secret
-#zabbix_agent_tlspskfile: ''
+# zabbix_agent_tlspskidentity:
+# zabbix_agent_tlspsk_secret
+# zabbix_agent_tlspskfile: ''

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -224,6 +224,10 @@
     inventory_mode: "{{ zabbix_inventory_mode }}"
     interfaces: "{{ zabbix_agent_interfaces }}"
     visible_name: "{{ zabbix_visible_hostname|default(zabbix_agent_hostname) }}"
+    tls_accept: "{{ encryption_types[zabbix_agent_tlsconnect|default('unencrypted')] }}"
+    tls_connect: "{{ encryption_types[zabbix_agent_tlsaccept|default('unencrypted')] }}"
+    tls_psk_identity: "{{ zabbix_agent_tlspskidentity|default('') }}"
+    tls_psk: "{{ zabbix_agent_tlspsk_secret|default('') }}"
   when:
     - zabbix_api_create_hosts
   become: no

--- a/vars/zabbix.yml
+++ b/vars/zabbix.yml
@@ -1,5 +1,10 @@
 ---
 
+encryption_types:
+  unencrypted: 1
+  psk:         2
+  cert:        4
+
 sign_keys:
   "34":
     bionic:

--- a/vars/zabbix.yml
+++ b/vars/zabbix.yml
@@ -2,8 +2,8 @@
 
 encryption_types:
   unencrypted: 1
-  psk:         2
-  cert:        4
+  psk: 2
+  cert: 4
 
 sign_keys:
   "34":


### PR DESCRIPTION
**Description of PR**
When the zabbix agent is configured to use PSK encryption (using `zabbix_agent_tlsaccept`...) it is desireable that the corresponting zabbix host will also be configured using the same encryption values (PSK and PSK identity).
This PR adds the implementation that will configure the zabbix host so that is will communicate with the agent encrypted.

**Type of change**
Feature Pull Request
(might also be seen as a Bugfix Pull Request)

**Example  using `host_vars/myhost`**
```
zabbix_agent_tlsaccept: psk
zabbix_agent_tlsconnect: psk
zabbix_agent_tlspskidentity: "myhost PSK"
zabbix_agent_tlspsk_secret: b7e3d380b9d400676d47198ecf3592ccd4795a59668aa2ade29f0003abbbd40d
zabbix_agent_tlspskfile: /etc/zabbix/zabbix_agent_pskfile.psk
```