### PR TITLE
remove deprecated loop

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -72,11 +72,10 @@
 # See also: http://askubuntu.com/questions/75565/why-am-i-getting-authentication-errors-for-packages-from-an-ubuntu-repository
 - name: "Debian | Installing zabbix-agent"
   apt:
-    pkg: "{{ item }}"
+    pkg: "{{ zabbix_agent_packages }}"
     state: "{{ zabbix_agent_package_state }}"
     update_cache: yes
     cache_valid_time: 0
-  with_items: "{{ zabbix_agent_packages }}"
   when: ansible_distribution in ['Ubuntu', 'Debian']
   become: yes
   tags:

--- a/tasks/Suse.yml
+++ b/tasks/Suse.yml
@@ -6,11 +6,8 @@
 
 - name: "Install zypper repo dependency"
   zypper:
-    name: "{{ item }}"
+    name: ["python-libxml2", "python-xml"]
     state: present
-  with_items:
-    - python-libxml2
-    - python-xml
   become: yes
   register: dependency
 
@@ -28,10 +25,9 @@
 
 - name: "Suse | Install zabbix-agent"
   zypper:
-    name: "{{ item }}"
+    name: "{{ zabbix_agent_packages }}"
     state: "{{ zabbix_agent_package_state }}"
     disable_gpg_check: yes
-  with_items: "{{ zabbix_agent_packages }}"
   become: yes
   tags:
     - zabbix-agent


### PR DESCRIPTION
**Description of PR**
installing packages using with_items is deprecated in Ansible 2.7:
https://docs.ansible.com/ansible/devel/porting_guides/porting_guide_2.7.html#using-a-loop-on-a-package-module-via-squash-actions

Replaced with a list syntax, which is supported since 2.3.

**Type of change**
Bugfix Pull Request

**Fixes an issue**
fixes deprecation warning since Ansible 2.7
```
TASK [dj-wasabi.zabbix-agent : Debian | Installing zabbix-agent] *************************************************************************************************************
[DEPRECATION WARNING]: Invoking "apt" only once while using a loop via squash_actions is deprecated. Instead of using a loop to supply multiple items and specifying `pkg: {{
 item }}`, please use `pkg: u'{{ zabbix_agent_packages }}'` and remove the loop. This feature will be removed in version 2.11. Deprecation warnings can be disabled by
setting deprecation_warnings=False in ansible.cfg.
```