### PR TITLE
Fix when running ansible in --check mode

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -78,7 +78,7 @@
     cache_valid_time: 0
   when: ansible_distribution in ['Ubuntu', 'Debian']
   become: yes
-  check_mode: no  
+  check_mode: no
   tags:
     - zabbix-agent
     - init

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -78,6 +78,7 @@
     cache_valid_time: 0
   when: ansible_distribution in ['Ubuntu', 'Debian']
   become: yes
+  check_mode: no  
   tags:
     - zabbix-agent
     - init

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -110,12 +110,12 @@
   when: 'getenforce_bin.stat.exists'
   changed_when: false
   become: yes
-
+  check_mode: no  
+  
 - name: "Set zabbix_selinux to true if getenforce returns Enforcing or Permissive"
   set_fact:
     zabbix_selinux: "{{ true }}"
   when: 'getenforce_bin.stat.exists and ("Enforcing" in sestatus.stdout or "Permissive" in sestatus.stdout)'
-  check_mode: no  
 
 - name: "Allow zabbix_agent to start (SELinux)"
   selinux_permissive:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -110,8 +110,8 @@
   when: 'getenforce_bin.stat.exists'
   changed_when: false
   become: yes
-  check_mode: no  
-  
+  check_mode: no
+
 - name: "Set zabbix_selinux to true if getenforce returns Enforcing or Permissive"
   set_fact:
     zabbix_selinux: "{{ true }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -115,6 +115,7 @@
   set_fact:
     zabbix_selinux: "{{ true }}"
   when: 'getenforce_bin.stat.exists and ("Enforcing" in sestatus.stdout or "Permissive" in sestatus.stdout)'
+  check_mode: no  
 
 - name: "Allow zabbix_agent to start (SELinux)"
   selinux_permissive:


### PR DESCRIPTION
**Description of PR**
role is failing on Ubuntu 16.04 xenial when used with --check mode
`ansible-playbook zabbix-agent.yml -i production --limit myshost -vvvv --check`

**Type of change**
Bugfix Pull Request

**Fixes an issue**
zabbix-sender  package does not exists on xenial, check mode do not like it
`"msg": "No package matching 'zabbix-sender' is available"`
getenforce return Disabled on xenial

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dj-wasabi/ansible-zabbix-agent/163)
<!-- Reviewable:end -->
