### PR TITLE
Some minor changes regarding documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Below an overview of all changes in the releases.
 
 Version (Release date)
 
+x.x.x  (unreleased)
+
+  * Add Windows
+  * Firewalld #166 (By pull request: 0utsider (Thanks!))
+  * Using same container as with the server #167
+
 1.4.0  (2018-09-11)
 
   * Add configuration to prevent host updating via zabbix api #150 (By pull request: sblaisot (Thanks!))

--- a/README.md
+++ b/README.md
@@ -240,9 +240,11 @@ Host encryption configuration will be set to match agent configuration.
 
 ## Windows Variables
 
-NOTE: Supporting Windows is an best effort (I don't have the possibility to either test/verify changes). PR's specific to Windows will almost immediately be merged.
+**NOTE**
 
-* `zabbix_version_long`: The long (major.minor.patch) version of the Zabbix Agent. 
+_Supporting Windows is an best effort (I don't have the possibility to either test/verify changes on the various amount of available Windows instances). PR's specific to Windows will almost immediately be merged, unless some one is able to provide a Windows test mechanism via Travis for Pull Requests._
+
+* `zabbix_version_long`: The long (major.minor.patch) version of the Zabbix Agent. This will be used with the `zabbix_win_download_link` link. If `zabbix_win_download_link` is provided, then there is no need to configure this property.
 
 * `zabbix_win_download_link`: The download url to the `win.zip` file.
 

--- a/tasks/Windows.yml
+++ b/tasks/Windows.yml
@@ -1,5 +1,15 @@
 ---
 
+- name: "Set default architecture"
+  set_fact:
+    windows_arch: 32
+
+- name: "Override architecture if 64-bit"
+  set_fact:
+    windows_arch: 64
+  when:
+    - ansible_architecture == "64-bit"
+
 - name: "Windows | Create directory structure"
   win_file:
     path: "{{ item }}"
@@ -23,7 +33,7 @@
   win_unzip:
     src: '{{ zabbix_win_install_dir }}\zabbix_agents_{{ zabbix_version_long }}.win.zip'
     dest: "{{ zabbix_win_install_dir }}"
-    creates: '{{ zabbix_win_install_dir }}\bin\win64\zabbix_agentd.exe'
+    creates: '{{ zabbix_win_install_dir }}\bin\win{{ windows_arch }}\zabbix_agentd.exe'
 
 - name: "Windows | Configure zabbix-agent"
   win_template:
@@ -31,7 +41,7 @@
     dest: '{{ zabbix_win_install_dir }}\zabbix_agentd.conf'
 
 - name: "Windows | Register Service"
-  win_command: '{{ zabbix_win_install_dir }}\bin\win64\zabbix_agentd.exe --config {{ zabbix_win_install_dir }}\zabbix_agentd.conf --install'
+  win_command: '{{ zabbix_win_install_dir }}\bin\win{{ windows_arch }}\zabbix_agentd.exe --config {{ zabbix_win_install_dir }}\zabbix_agentd.conf --install'
   register: zabbix_windows_install
   args:
     creates: '{{ zabbix_win_install_dir }}\.installed'
@@ -51,7 +61,7 @@
 - name: "Windows | Firewall rule"
   win_firewall_rule:
     name: Zabbix Agent
-    localport: 10050
+    localport: "{{ zabbix_agent_listenport }}"
     action: allow
     direction: in
     protocol: tcp


### PR DESCRIPTION
**Description of PR**

* Updated changelog;
* Added some clarification in documentation about Windows;
* Determine architecture to use the service with the `win32/zabbix-agentd.exe` or the `win64/zabbix-agentd.exe`;
* Usage of the `zabbix_agent_listenport` for the Firewall configuration;

**Type of change**
<!--- Pick one below and delete the rest: -->

Docs Pull Request

**Fixes an issue**
<!--- If this PR fixes an issue, please mention it. -->
