### PR TITLE
Custom location if userparameter files and scripts directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,8 +404,8 @@ The Ubuntu agent will register itself via a PSK, so that communication between t
 
 The following steps are required to install custom userparameters and/or scripts:
 
-* Put the desired userparameter file in the `templates/userparameters` directory and name it as `<userparameter_name>.j2`. For example: `templates/userparameters/mysql.j2`
-* Put the scripts directory (if any) in the `files/scripts` directory. For example: `files/scripts/mysql`
+* Put the desired userparameter file in the `templates/userparameters` directory and name it as `<userparameter_name>.j2`. For example: `templates/userparameters/mysql.j2`. You may specify custom location on the localhost, where userparameter files will be placed with `zabbix_userparameters_localpath` variable.
+* Put the scripts directory (if any) in the `files/scripts` directory. For example: `files/scripts/mysql`. You may specify custom folder, under which scripts directory will be placed with `zabbix_userscripts_localpath` variable.
 * Add `zabbix_agent_userparameters` variable to the playbook as a list of dictionaries and define userparameter name and scripts directory name (if there are no scripts just no not specify the `scripts_dir` variable).
 
 Example:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -86,6 +86,8 @@ zabbix_agent_userparameters: []
 zabbix_agent_custom_scripts: false
 zabbix_agent_loadmodulepath: ${libdir}/modules
 zabbix_agent_loadmodule:
+zabbix_userparameters_localpath: "userparameters"
+zabbix_userscripts_localpath: "scripts"
 
 # TLS settings
 zabbix_agent_tlsconnect:

--- a/tasks/userparameter.yml
+++ b/tasks/userparameter.yml
@@ -2,8 +2,8 @@
 
 - name: "Installing user-defined userparameters"
   template:
-    src: "{{ zabbix_userparameters_localpath }}/{{ item.name }}.j2"
-    dest: "{{ zabbix_agent_include }}/userparameter_{{ item.name }}.conf"
+    src: "{{ item.path }}/{{ item.name }}"
+    dest: "{{ zabbix_agent_include }}/userparameter_{{ item.name.split('.j2')[0] }}"
     owner: zabbix
     group: zabbix
     mode: 0644
@@ -13,7 +13,7 @@
 
 - name: "Installing user-defined scripts"
   copy:
-    src: "{{ zabbix_userscripts_localpath }}/{{ item.scripts_dir }}"
+    src: "{{ item.scripts_dir }}"
     dest: "/etc/zabbix/scripts/"
     owner: zabbix
     group: zabbix

--- a/tasks/userparameter.yml
+++ b/tasks/userparameter.yml
@@ -2,7 +2,7 @@
 
 - name: "Installing user-defined userparameters"
   template:
-    src: "userparameters/{{ item.name }}.j2"
+    src: "{{ zabbix_userparameters_localpath }}/{{ item.name }}.j2"
     dest: "{{ zabbix_agent_include }}/userparameter_{{ item.name }}.conf"
     owner: zabbix
     group: zabbix
@@ -13,7 +13,7 @@
 
 - name: "Installing user-defined scripts"
   copy:
-    src: "scripts/{{ item.scripts_dir }}"
+    src: "{{ zabbix_userscripts_localpath }}/{{ item.scripts_dir }}"
     dest: "/etc/zabbix/scripts/"
     owner: zabbix
     group: zabbix


### PR DESCRIPTION
Added ability to provide custom location of userparameters files and
custom check scripts. This is useful, as do not require role fork
in case of adding userparameters file. Also it makes possible to add role
as a submodule of existing roles set.

Provided defaults won't make any changes in logic,
unless they will be overrided.

**Description of PR**
<!--- Describe what the PR holds -->
Added variables `zabbix_userparameters_localpath` and `zabbix_userscripts_localpath`,
which are used in order to specify custom directories for userparameters and scripts outside of the role.

**Type of change**
<!--- Pick one below and delete the rest: -->
Feature Pull Request

**Fixes an issue**
<!--- If this PR fixes an issue, please mention it. -->
