### PR TITLE
enable support for https enabled zabbix frontends/apis

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ These variables are specific for Zabbix 3.0 and higher:
 
 ## Zabbix API variables
 
-These variables needs to be changed/overriden when you want to make use of the zabbix-api for automatically creating and or updating hosts.
+These variables needs to be changed/overriden when you want to make use of the zabbix-api for automatically creating and or updating hosts. 
 
 Host encryption configuration will be set to match agent configuration.
 
@@ -259,6 +259,8 @@ Host encryption configuration will be set to match agent configuration.
 * `zabbix_inventory_mode`: Configure Zabbix inventory mode. Needed for building inventory data, manually when configuring a host or automatically by using some automatic population options. This has to be set to `automatic` if you want to make automatically building inventory data.
 
 * `zabbix_visible_hostname` : Configure Zabbix visible name inside Zabbix web UI for the node.
+
+* `zabbix_validate_certs` : yes (Default) if we need to validate tls certificates of the API. Use `no` in case self-signed certificates are used
 
 ## Windows Variables
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -113,6 +113,7 @@
     login_password: "{{ zabbix_api_pass }}"
     host_group: "{{ zabbix_host_groups }}"
     state: "{{ zabbix_create_hostgroup }}"
+    validate_certs: "{{ zabbix_validate_certs|default(omit) }}"
   when:
     - zabbix_api_create_hostgroup
   become: no
@@ -141,6 +142,7 @@
     tls_subject: "{{ zabbix_agent_tlsservercertsubject|default(omit) }}"
     tls_connect: "{{ {'unencrypted': '1', 'psk': '2', 'cert' : '4'}[zabbix_agent_tlsaccept if zabbix_agent_tlsaccept else 'unencrypted'] }}"
     tls_accept: "{{ {'unencrypted': '1', 'psk': '2', 'cert' : '4'}[zabbix_agent_tlsconnect if zabbix_agent_tlsconnect else 'unencrypted'] }}"
+    validate_certs: "{{ zabbix_validate_certs|default(omit) }}"
   when:
     - zabbix_api_create_hosts
   become: no
@@ -157,6 +159,7 @@
     host_name: "{{ zabbix_agent_hostname }}"
     macro_name: "{{ item.macro_key }}"
     macro_value: "{{ item.macro_value }}"
+    validate_certs: "{{ zabbix_validate_certs|default(omit) }}"
   with_items: "{{ zabbix_macros | default([]) }}"
   when:
     - zabbix_macros is defined


### PR DESCRIPTION


**Description of PR**
 enable support for https enabled zabbix frontends/apis with self signed certificates
allow disabling of validation for self signed certificates for the zabbix api/frontend for the modules zabbix_host, zabbix_group and zabbix_hostmacro

**Type of change**
Bugfix Pull Request

**Fixes an issue**

