### PR TITLE
Fixes yum, and apt deprecation warnings by removing the loop

### DIFF
--- a/molecule/before-last-version/playbook.yml
+++ b/molecule/before-last-version/playbook.yml
@@ -4,20 +4,18 @@
   pre_tasks:
     - name: "Installing packages on CentOS family"
       yum:
-        name: "{{ item }}"
+        name:
+          - net-tools
+          - which
         state: present
-      with_items:
-        - net-tools
-        - which
       when:
         - ansible_os_family == 'RedHat'
 
     - name: "Installing packages on Debian family"
       apt:
-        name: "{{ item }}"
+        name:
+          - net-tools
         state: present
-      with_items:
-        - net-tools
       when:
         - ansible_os_family == 'Debian'
 

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -4,20 +4,18 @@
   pre_tasks:
     - name: "Installing packages on CentOS family"
       yum:
-        name: "{{ item }}"
+        name:
+          - net-tools
+          - which
         state: present
-      with_items:
-        - net-tools
-        - which
       when:
         - ansible_os_family == 'RedHat'
 
     - name: "Installing packages on Debian family"
       apt:
-        name: "{{ item }}"
+        name:
+          - net-tools
         state: present
-      with_items:
-        - net-tools
       when:
         - ansible_os_family == 'Debian'
 

--- a/molecule/with-server/prepare.yml
+++ b/molecule/with-server/prepare.yml
@@ -10,24 +10,22 @@
 
     - name: "Installing packages"
       yum:
-        name: "{{ item }}"
+        name:
+          - net-tools
+          - which
+          - libselinux-python
+          - python-pip
         state: present
-      with_items:
-        - net-tools
-        - which
-        - libselinux-python
-        - python-pip
       register: installation_dependencies
       when: ansible_distribution == 'CentOS'
 
     - name: "Installing which on NON-CentOS"
       apt:
-        name: "{{ item }}"
+        name:
+          - net-tools
+          - python-pip
+          - curl
         state: present
-      with_items:
-        - net-tools
-        - python-pip
-        - curl
       when: ansible_distribution != 'CentOS'
 
     - name: "Configure SUDO."
@@ -57,19 +55,17 @@
   tasks:
     - name: "Installing packages on CentOS family"
       yum:
-        name: "{{ item }}"
+        name:
+          - net-tools
+          - which
         state: present
-      with_items:
-        - net-tools
-        - which
       when:
         - ansible_os_family == 'RedHat'
 
     - name: "Installing packages on Debian family"
       apt:
-        name: "{{ item }}"
+        name:
+          - net-tools
         state: present
-      with_items:
-        - net-tools
-      when:
+       when:
         - ansible_os_family == 'Debian'

--- a/molecule/with-server/prepare.yml
+++ b/molecule/with-server/prepare.yml
@@ -4,7 +4,8 @@
   pre_tasks:
     - name: "Installing EPEL"
       yum:
-        name: epel-release
+        name:
+          - epel-release
         state: present
       when: ansible_distribution == 'CentOS'
 

--- a/molecule/with-server/prepare.yml
+++ b/molecule/with-server/prepare.yml
@@ -68,5 +68,5 @@
         name:
           - net-tools
         state: present
-       when:
+      when:
         - ansible_os_family == 'Debian'


### PR DESCRIPTION
Description of PR
Fixes Deprecation warnings with the upgrade to Ansible 2.7.
Specifically it removes the loop that is no longer needed with the upgrade.

Type of change
Feature Pull Request

Fixes an issue

Fixes following Deprecation Warnings

[DEPRECATION WARNING]: Invoking "apt" only once while using a loop via squash_actions is deprecated. Instead of using a loop to supply multiple items and specifying name: {{ item }}, please use name: [u'snappy', u'snappy- devel', u'zlib', u'zlib-devel', u'hwloc', u'gcc', u'lzo', u'lzo-devel', u'python', u'make'] and remove the loop. This feature will be removed in version 2.11. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.

[DEPRECATION WARNING]: Invoking "yum" only once while using a loop via squash_actions is deprecated. Instead of using a loop to supply multiple items and specifying name: {{ item }}, please use name: [u'snappy', u'snappy- devel', u'zlib', u'zlib-devel', u'hwloc', u'gcc', u'lzo', u'lzo-devel', u'python', u'make'] and remove the loop. This feature will be removed in version 2.11. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.