### PR TITLE
SourceIP instead of sourceip

### DIFF
--- a/templates/zabbix_agentd.conf.j2
+++ b/templates/zabbix_agentd.conf.j2
@@ -42,7 +42,7 @@ DebugLevel={{ zabbix_agent_debuglevel }}
 #       source ip address for outgoing connections.
 #
 {% if zabbix_agent_sourceip is defined and zabbix_agent_sourceip %}
-sourceip={{ zabbix_agent_sourceip }}
+SourceIP={{ zabbix_agent_sourceip }}
 {% endif %}
 
 ### option: enableremotecommands


### PR DESCRIPTION
**Description of PR**
The Zabbix variable in the template should be called 'SourceIP' instead of 'sourceip'. Otherwise the agent won't start.

**Type of change**
Bugfix Pull Request