### PR TITLE
Added a until loop to retry installations as suggested by ansible-lint

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -81,6 +81,8 @@
     update_cache: yes
     cache_valid_time: 0
   when: ansible_distribution in ['Ubuntu', 'Debian']
+  register: zabbix_agent_package_installed
+  until: zabbix_agent_package_installed is succeeded
   become: yes
   check_mode: no
   tags:
@@ -94,6 +96,8 @@
     update_cache: yes
     cache_valid_time: 0
   when: ansible_distribution not in ['Ubuntu', 'Debian']
+  register: zabbix_agent_package_installed
+  until: zabbix_agent_package_installed is succeeded
   become: yes
   tags:
     - zabbix-agent
@@ -105,6 +109,8 @@
     state: installed
     update_cache: yes
     cache_valid_time: 0
+  register: zabbix_agent_policycoreutils_installed
+  until: zabbix_agent_package_installed is succeeded
   become: yes
   when: zabbix_selinux
 

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -51,6 +51,8 @@
       - "{{ zabbix_sender_package }}"
       - "{{ zabbix_get_package }}"
     state: "{{ zabbix_agent_package_state }}"
+  register: zabbix_agent_package_installed
+  until: zabbix_agent_package_installed is succeeded
   become: yes
   tags:
     - init
@@ -60,6 +62,8 @@
   package:
     name: policycoreutils-python
     state: installed
+  register: zabbix_agent_policycoreutils_installed
+  until: zabbix_agent_package_installed is succeeded
   when: zabbix_selinux
   become: yes
   tags:

--- a/tasks/Suse.yml
+++ b/tasks/Suse.yml
@@ -28,6 +28,8 @@
     name: "{{ zabbix_agent_packages }}"
     state: "{{ zabbix_agent_package_state }}"
     disable_gpg_check: yes
+  register: zabbix_agent_package_installed
+  until: zabbix_agent_package_installed is succeeded
   become: yes
   tags:
     - zabbix-agent

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -134,6 +134,8 @@
   pip:
     name: zabbix-api
     state: present
+  register: zabbix_api_package_installed
+  until: zabbix_api_package_installed is succeeded
   delegate_to: localhost
   become: True
   when:


### PR DESCRIPTION
**Description of PR**
Added an until as suggested for the `ansible-lint` rule to fix issue:

`E405:  Remote package tasks should have a retry`

**Type of change**
<!--- Pick one below and delete the rest: -->

Feature Pull Request

**Fixes an issue**
<!--- If this PR fixes an issue, please mention it. -->
