### PR TITLE
Add fedora 29 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ This is one of the 'dj-wasabi' roles which configures your whole Zabbix environm
 This role will work on the following operating systems:
 
  * Red Hat
+ * Fedora
  * Debian
  * Ubuntu
  * opensuse
@@ -72,6 +73,7 @@ See the following list of supported Operating systems with the Zabbix releases:
   * CentOS 7.x
   * Amazon 7.x
   * RedHat 7.x
+  * Fedora 27, 29
   * OracleLinux 7.x
   * Scientific Linux 7.x
   * Ubuntu 14.04, 16.04, 18.04
@@ -82,6 +84,7 @@ See the following list of supported Operating systems with the Zabbix releases:
   * CentOS 7.x
   * Amazon 7.x
   * RedHat 7.x
+  * Fedora 27, 29
   * OracleLinux 7.x
   * Scientific Linux 7.x
   * Ubuntu 14.04, 16.04, 18.04
@@ -92,6 +95,7 @@ See the following list of supported Operating systems with the Zabbix releases:
   * CentOS 7.x
   * Amazon 7.x
   * RedHat 7.x
+  * Fedora 27, 29
   * OracleLinux 7.x
   * Scientific Linux 7.x
   * Ubuntu 14.04, 16.04

--- a/tasks/Linux.yml
+++ b/tasks/Linux.yml
@@ -43,6 +43,21 @@
     - config
     - init
 
+- name: Copy zabbix_agent template for Fedora OS
+  copy:
+    src: /etc/zabbix/zabbix_agentd.conf
+    dest: /etc/zabbix_agentd.conf
+    remote_src: yes
+    owner: root
+    group: root
+    mode: 0644
+  when: ansible_distribution == "Fedora"
+  notify: restart zabbix agent
+  tags:
+    - zabbix-agent
+    - config
+    - init
+
 - name: "Create directory for PSK file if not exist."
   file:
     path: "{{ zabbix_agent_tlspskfile | dirname }}"

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -37,7 +37,7 @@
   register: yum_repo_installed
   become: yes
   when:
-    - zabbix_repo == "zabbix"
+    zabbix_repo == "zabbix"
   tags:
     - zabbix-agent
 

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -19,6 +19,12 @@
     - ansible_distribution == "Amazon"
     - ansible_distribution_major_version == "NA"
 
+- name: "Fedora | Set ansible_distribution_major_version to 7 when Fedora"
+  set_fact:
+    ansible_distribution_major_version: 7
+  when:
+    - ansible_distribution == "Fedora"
+
 - name: "RedHat | Install basic repo file"
   yum_repository:
     name: "{{ item.name }}"
@@ -31,7 +37,7 @@
   register: yum_repo_installed
   become: yes
   when:
-    zabbix_repo == "zabbix"
+    - zabbix_repo == "zabbix"
   tags:
     - zabbix-agent
 


### PR DESCRIPTION
**Description of PR**
Added support for Zabbix Agent (version 3.2, 3.4, and 4.0) being installed on Fedora 27 and 29 systems.  

**Type of change**
Feature Pull Request

**Fixes an issue**
