### PR TITLE
corrected own mistake for Fedora directory

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,7 +10,6 @@ zabbix_agent_package_state: present
 zabbix_agent_server:
 zabbix_agent_serveractive:
 zabbix_selinux: False
-zabbix_agent_conf_dir: /etc/zabbix
 
 zabbix_repo_yum:
   - name: zabbix

--- a/tasks/Linux.yml
+++ b/tasks/Linux.yml
@@ -31,7 +31,7 @@
 - name: "Configure zabbix-agent"
   template:
     src: zabbix_agentd.conf.j2
-    dest: "{{ zabbix_agent_conf_dir }}/{{ zabbix_agent_conf }}"
+    dest: "/etc/zabbix/{{ zabbix_agent_conf }}"
     owner: root
     group: root
     mode: 0644

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -22,7 +22,6 @@
 - name: "Fedora | Modify ansible_distribution_major_version and zabbix_agent_conf_dir when Fedora"
   set_fact:
     ansible_distribution_major_version: 7
-    zabbix_agent_conf_dir: /etc
   when:
     - ansible_distribution == "Fedora"
 


### PR DESCRIPTION
**Description of PR**
Corrected my own previous PR.  #199 

Realized with Fedora 27 and 29 and Zabbix agents v3.2+ the working directory became the standard `/etc/zabbix/`.  Corrected this change.  

**Type of change**

Bugfix Pull Request

**Fixes an issue**
Fixes location where `zabbix_agentd.conf` file is stored for Fedora OS'.  
