### PR TITLE
Set default values if property is undefined

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -58,8 +58,8 @@
 - name: "Set first public ip address for zabbix_agent_ip"
   set_fact:
     zabbix_agent_ip: "{{ ansible_all_ipv4_addresses | ipaddr('public') | first }}"
-    zabbix_agent_server: "{{ zabbix_agent_server_public_ip }}"
-    zabbix_agent_serveractive: "{{ zabbix_agent_serveractive_public_ip }}"
+    zabbix_agent_server: "{{ zabbix_agent_server_public_ip | default(zabbix_agent_server) }}"
+    zabbix_agent_serveractive: "{{ zabbix_agent_serveractive_public_ip | default(zabbix_agent_serveractive) }}"
   when:
     - zabbix_agent_ip is not defined
     - total_private_ip_addresses is defined


### PR DESCRIPTION
**Description of PR**
<!--- Describe what the PR holds -->

Property `zabbix_agent_server_public_ip` is undefined. If property is not defined in playbook configuration or in group_vars (or host_vars), we use the one with the `_public_ip`.

**Type of change**
<!--- Pick one below and delete the rest: -->

Bugfix Pull Request

**Fixes an issue**
<!--- If this PR fixes an issue, please mention it. -->
Fixes #202