### PR TITLE
Add option not to elevate privileges locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,8 @@ There are some variables in de default/main.yml which can (Or needs to) be overr
 
 * `zabbix_agent_runas_user`: Drop privileges to a specific, existing user on the system. Only has effect if run as 'root' and AllowRoot is disabled.
 
+* `zabbix_agent_become_on_localhost`: Set to `False` if you don't need to elevate privileges on localhost to install packages locally with pip. Default: True
+
 ## TLS Specific configuration
 
 These variables are specific for Zabbix 3.0 and higher:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -84,6 +84,7 @@ zabbix_agent_userparameters: []
 zabbix_agent_custom_scripts: false
 zabbix_agent_loadmodulepath: ${libdir}/modules
 zabbix_agent_loadmodule:
+zabbix_agent_become_on_localhost: True
 
 # TLS settings
 zabbix_agent_tlsconnect:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -56,7 +56,7 @@
   register: zabbix_python_netaddr_package_installed
   until: zabbix_python_netaddr_package_installed is succeeded
   delegate_to: localhost
-  become: True
+  become: "{{ zabbix_agent_become_on_localhost }}"
   when:
     - ansible_all_ipv4_addresses is defined or (zabbix_agent_ip is not defined and total_private_ip_addresses is defined)
 
@@ -148,7 +148,7 @@
   register: zabbix_api_package_installed
   until: zabbix_api_package_installed is succeeded
   delegate_to: localhost
-  become: True
+  become: "{{ zabbix_agent_become_on_localhost }}"
   when:
     - zabbix_api_create_hostgroup or zabbix_api_create_hosts
 


### PR DESCRIPTION
**Description of PR**
This PR adds an option not to elevate privileges locally when installing pip-packages on localhost. You don't always need to be root to install these packages locally (i.e. on macOS).

**Type of change**
Feature Pull Request
