### PR TITLE
Windows zabbix agent handler

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -10,3 +10,9 @@
 
 - name: firewalld-reload
   command: "firewall-cmd --reload"
+
+- name: restart win zabbix agent
+  win_service:
+    name: "{{ zabbix_win_agent_service }}"
+    state: restarted
+    enabled: yes

--- a/tasks/Windows.yml
+++ b/tasks/Windows.yml
@@ -50,6 +50,7 @@
   win_template:
     src: zabbix_agentd.conf.j2
     dest: '{{ zabbix_win_install_dir }}\zabbix_agentd.conf'
+  notify: restart win zabbix agent
 
 - name: "Windows | Register Service"
   win_command: '{{ zabbix_win_exe_path }} --config {{ zabbix_win_install_dir }}\zabbix_agentd.conf --install'

--- a/vars/Windows.yml
+++ b/vars/Windows.yml
@@ -1,1 +1,4 @@
 ---
+# vars file for zabbix agent (Windows)
+
+zabbix_win_agent_service: "zabbix agent"


### PR DESCRIPTION
**Description of PR**
This PR introduces a windows zabbix agent handler in the role.
Currently there's no restart when the configuration has changed and when including the role into another playbook, it's impossible to retrieve the fact that the configuration has changed to trigger it externally, thus the proposed addition.

**Type of change**
Feature Pull Request
