### PR TITLE
Using the correct properties

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -186,8 +186,8 @@
     tls_psk_identity: "{{ zabbix_agent_tlspskidentity|default(omit) }}"
     tls_issuer: "{{ zabbix_agent_tlsservercertissuer|default(omit) }}"
     tls_subject: "{{ zabbix_agent_tlsservercertsubject|default(omit) }}"
-    tls_connect: "{{ zabbix_agent_tls_config[zabbix_agent_tlsaccept if zabbix_agent_tlsaccept else 'unencrypted'] }}"
-    tls_accept: "{{ zabbix_agent_tls_config[zabbix_agent_tlsconnect if zabbix_agent_tlsconnect else 'unencrypted'] }}"
+    tls_accept: "{{ zabbix_agent_tls_config[zabbix_agent_tlsaccept if zabbix_agent_tlsaccept else 'unencrypted'] }}"
+    tls_connect: "{{ zabbix_agent_tls_config[zabbix_agent_tlsconnect if zabbix_agent_tlsconnect else 'unencrypted'] }}"
     validate_certs: "{{ zabbix_validate_certs|default(omit) }}"
   when:
     - zabbix_api_create_hosts


### PR DESCRIPTION
**Description of PR**
<!--- Describe what the PR holds -->
Property was used in wrong task argument. `zabbix_agent_tlsaccept` was used for the `tls_connect` and vice versa, is now corrected.

**Type of change**
<!--- Pick one below and delete the rest: -->

Bugfix Pull Request

**Fixes an issue**
<!--- If this PR fixes an issue, please mention it. -->
Fixes #205