### PR TITLE
Pip packages install variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,8 @@ There are some variables in de default/main.yml which can (Or needs to) be overr
 
 * `zabbix_agent_become_on_localhost`: Set to `False` if you don't need to elevate privileges on localhost to install packages locally with pip. Default: True
 
+* `zabbix_install_pip_packages`: Set to `False` if you don't want to install the required pip packages. Useful when you control your environment completely. Default: True
+
 ## TLS Specific configuration
 
 These variables are specific for Zabbix 3.0 and higher:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,9 @@ zabbix_agent_server:
 zabbix_agent_serveractive:
 zabbix_selinux: False
 
+# Zabbix role related vars
+zabbix_install_pip_packages: true
+
 # Override Ansible specific facts
 zabbix_agent_distribution_major_version: "{{ ansible_distribution_major_version }}"
 zabbix_agent_distribution_release: "{{ ansible_distribution_release }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -58,6 +58,7 @@
   delegate_to: localhost
   become: "{{ zabbix_agent_become_on_localhost }}"
   when:
+    - zabbix_install_pip_packages
     - ansible_all_ipv4_addresses is defined or (zabbix_agent_ip is not defined and total_private_ip_addresses is defined)
 
 - name: "Get Total Private IP Addresses"
@@ -150,6 +151,7 @@
   delegate_to: localhost
   become: "{{ zabbix_agent_become_on_localhost }}"
   when:
+    - zabbix_install_pip_packages
     - zabbix_api_create_hostgroup or zabbix_api_create_hosts
 
 - name: "Create hostgroups"


### PR DESCRIPTION
**Description of PR**
This PR adds the `zabbix_install_pip_packages` so that we can disable the installation of pip packages when executing the role.
This is especially useful when you have a tight control on the environment you execute the role in.

**Type of change**
Feature Pull Request

Let me know if you think this is really out of scope.
