### PR TITLE
Added task that was previously in role

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -61,6 +61,13 @@
     - zabbix_install_pip_packages
     - ansible_all_ipv4_addresses is defined or (zabbix_agent_ip is not defined and total_private_ip_addresses is defined)
 
+- name: "Set default ip address for zabbix_agent_ip"
+  set_fact:
+    zabbix_agent_ip: "{{ hostvars[inventory_hostname]['ansible_default_ipv4'].address }}"
+  when:
+    - zabbix_agent_ip is not defined
+    - "'ansible_default_ipv4' in hostvars[inventory_hostname]"
+
 - name: "Get Total Private IP Addresses"
   set_fact:
     total_private_ip_addresses: "{{ ansible_all_ipv4_addresses | ipaddr('private') | length }}"


### PR DESCRIPTION
**Description of PR**
Added a task that was previously in the role about discovering the ip. This would help solve the issue, I'm not sure about the users that use task `Set first public ip address for zabbix_agent_ip` to determine the `zabbix_agent_ip`.

**Type of change**
<!--- Pick one below and delete the rest: -->

Bugfix Pull Request

**Fixes an issue**
<!--- If this PR fixes an issue, please mention it. -->

Fixes #214 