### PR TITLE
Defining different jmx port number to configuring firewall

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ Keep in mind that using the Zabbix Agent in a Container, requires changes to the
 
 * `zabbix_agent_firewall_source`: When provided, IPtables will be configuring to only allow traffic from this IP address/range.
 
-* `zabbix_agent_firewalld_enable`: If firewalld needs to be updated by opening an TCP port for port configured in `zabbix_agent_listenport`.
+* `zabbix_agent_firewalld_enable`: If firewalld needs to be updated by opening an TCP port for port configured in `zabbix_agent_listenport` and `zabbix_agent_jmx_listenport` if defined.
 
 * `zabbix_agent_firewalld_source`: When provided, firewalld will be configuring to only allow traffic for IP configured in `zabbix_agent_server`.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -72,6 +72,7 @@ zabbix_agent_sourceip:
 zabbix_agent_enableremotecommands: 0
 zabbix_agent_logremotecommands: 0
 zabbix_agent_listenport: 10050
+zabbix_agent_jmx_listenport:
 zabbix_agent_listeninterface:
 zabbix_agent_listenip:
 zabbix_agent_startagents: 3

--- a/tasks/Linux.yml
+++ b/tasks/Linux.yml
@@ -106,7 +106,7 @@
   when:
     - zabbix_agent_docker
 
-- name: "Configure IPTables"
+- name: "Configure IPTables (zabbix_agent_listenport)"
   iptables:
     destination_port: "{{ zabbix_agent_listenport }}"
     source: "{{ zabbix_agent_firewall_source | default(omit) }}"
@@ -116,13 +116,34 @@
   become: yes
   when: zabbix_agent_firewall_enable
 
-- name: "Configure firewalld"
+- name: "Configure IPTables (zabbix_agent_jmx_listenport)"
+  iptables:
+    destination_port: "{{ zabbix_agent_listenport }}"
+    source: "{{ zabbix_agent_firewall_source | default(omit) }}"
+    protocol: tcp
+    chain: INPUT
+    jump: ACCEPT
+  become: yes
+  when: (zabbix_agent_firewall_enable and zabbix_agent_jmx_listenport)
+
+- name: "Configure firewalld (zabbix_agent_listenport)"
   firewalld:
     rich_rule: 'rule family="ipv4" source address="{{ zabbix_agent_firewalld_source }}" port protocol="tcp" port="{{ zabbix_agent_listenport }}" accept'
     permanent: true
     state: enabled
   become: yes
   when: zabbix_agent_firewalld_enable
+  notify:
+    - firewalld-reload
+  tags: zabbix_agent_firewalld_enable
+
+- name: "Configure firewalld (zabbix_agent_jmx_listenport)"
+  firewalld:
+    rich_rule: 'rule family="ipv4" source address="{{ zabbix_agent_firewalld_source }}" port protocol="tcp" port="{{ zabbix_agent_jmx_listenport }}" accept'
+    permanent: true
+    state: enabled
+  become: yes
+  when: (zabbix_agent_firewalld_enable and zabbix_agent_jmx_listenport)
   notify:
     - firewalld-reload
   tags: zabbix_agent_firewalld_enable


### PR DESCRIPTION
Improvement: defining different jmx port number - variable: (zabbix_agent_jmx_listenport)

**Description of PR**
jmx port in zabbix_host module has define to: 12345. I adding different variable (zabbix_agent_jmx_listenport) to define own jmx port to configuring firewall rules. 

**Type of change**
Feature Pull Request

