### PR TITLE
Update syntax to ansible 2.8

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,6 +14,8 @@ zabbix_selinux: False
 
 # Zabbix role related vars
 zabbix_install_pip_packages: true
+zabbix_apt_force_apt_get: yes
+zabbix_apt_install_recommends: no
 
 # Override Ansible specific facts
 zabbix_agent_distribution_major_version: "{{ ansible_distribution_major_version }}"

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -80,6 +80,8 @@
     state: "{{ zabbix_agent_package_state }}"
     update_cache: yes
     cache_valid_time: 0
+    force_apt_get: "{{ zabbix_apt_force_apt_get }}"
+    install_recommends: "{{ zabbix_apt_install_recommends }}"
   when: ansible_distribution in ['Ubuntu', 'Debian']
   register: zabbix_agent_package_installed
   until: zabbix_agent_package_installed is succeeded
@@ -95,6 +97,8 @@
     state: "{{ zabbix_agent_package_state }}"
     update_cache: yes
     cache_valid_time: 0
+    force_apt_get: "{{ zabbix_apt_force_apt_get }}"
+    install_recommends: "{{ zabbix_apt_install_recommends }}"
   when: ansible_distribution not in ['Ubuntu', 'Debian']
   register: zabbix_agent_package_installed
   until: zabbix_agent_package_installed is succeeded
@@ -109,10 +113,12 @@
     state: installed
     update_cache: yes
     cache_valid_time: 0
+    force_apt_get: "{{ zabbix_apt_force_apt_get }}"
+    install_recommends: "{{ zabbix_apt_install_recommends }}"
   register: zabbix_agent_policycoreutils_installed
   until: zabbix_agent_package_installed is succeeded
   become: yes
-  when: zabbix_selinux
+  when: zabbix_selinux | bool
 
 - name: "Debian | Enable the service"
   service:

--- a/tasks/Linux.yml
+++ b/tasks/Linux.yml
@@ -26,7 +26,7 @@
     permissive: true
   become: yes
   when:
-    - zabbix_selinux
+    - zabbix_selinux | bool
 
 - name: "Adding zabbix group"
   group:
@@ -35,7 +35,7 @@
     gid: "{{ zabbix_agent_docker_user_gid | default(omit) }}"
   become: yes
   when:
-    - zabbix_agent_docker
+    - zabbix_agent_docker | bool
 
 - name: "Adding zabbix user"
   user:
@@ -48,7 +48,7 @@
     system: True
   become: yes
   when:
-    - zabbix_agent_docker
+    - zabbix_agent_docker | bool
 
 - name: "Configure zabbix-agent"
   template:
@@ -61,7 +61,7 @@
     - restart zabbix-agent
   become: yes
   when:
-    - not zabbix_agent_docker
+    - not (zabbix_agent_docker | bool)
   tags:
     - zabbix-agent
     - config
@@ -104,7 +104,7 @@
 - name: "Install the Docker container"
   include: Docker.yml
   when:
-    - zabbix_agent_docker
+    - zabbix_agent_docker | bool
 
 - name: "Configure IPTables (zabbix_agent_listenport)"
   iptables:
@@ -114,7 +114,7 @@
     chain: INPUT
     jump: ACCEPT
   become: yes
-  when: zabbix_agent_firewall_enable
+  when: zabbix_agent_firewall_enable | bool
 
 - name: "Configure IPTables (zabbix_agent_jmx_listenport)"
   iptables:
@@ -124,7 +124,7 @@
     chain: INPUT
     jump: ACCEPT
   become: yes
-  when: (zabbix_agent_firewall_enable and zabbix_agent_jmx_listenport)
+  when: (zabbix_agent_firewall_enable  | bool) and (zabbix_agent_jmx_listenport | bool)
 
 - name: "Configure firewalld (zabbix_agent_listenport)"
   firewalld:
@@ -132,7 +132,7 @@
     permanent: true
     state: enabled
   become: yes
-  when: zabbix_agent_firewalld_enable
+  when: zabbix_agent_firewalld_enable | bool
   notify:
     - firewalld-reload
   tags: zabbix_agent_firewalld_enable
@@ -143,7 +143,7 @@
     permanent: true
     state: enabled
   become: yes
-  when: (zabbix_agent_firewalld_enable and zabbix_agent_jmx_listenport)
+  when: (zabbix_agent_firewalld_enable | bool) and (zabbix_agent_jmx_listenport | bool)
   notify:
     - firewalld-reload
   tags: zabbix_agent_firewalld_enable
@@ -155,7 +155,7 @@
     enabled: yes
   become: yes
   when:
-    - not zabbix_agent_docker
+    - not (zabbix_agent_docker | bool)
   tags:
     - init
     - service

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -70,7 +70,7 @@
     state: installed
   register: zabbix_agent_policycoreutils_installed
   until: zabbix_agent_package_installed is succeeded
-  when: zabbix_selinux
+  when: zabbix_selinux | bool
   become: yes
   tags:
     - init

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,7 +23,7 @@
   include: "RedHat.yml"
   when:
     - zabbix_agent_os_family == "RedHat"
-    - not zabbix_agent_docker
+    - not (zabbix_agent_docker | bool)
   tags:
     - zabbix-agent
     - init
@@ -34,7 +34,7 @@
   include: "Debian.yml"
   when:
     - zabbix_agent_os_family == "Debian"
-    - not zabbix_agent_docker
+    - not (zabbix_agent_docker | bool)
   tags:
     - zabbix-agent
     - init
@@ -45,7 +45,7 @@
   include: "Suse.yml"
   when:
     - zabbix_agent_os_family == "Suse"
-    - not zabbix_agent_docker
+    - not (zabbix_agent_docker | bool)
   tags:
     - zabbix-agent
     - init
@@ -61,7 +61,7 @@
   delegate_to: localhost
   become: "{{ zabbix_agent_become_on_localhost }}"
   when:
-    - zabbix_install_pip_packages
+    - zabbix_install_pip_packages | bool
     - ansible_all_ipv4_addresses is defined or (zabbix_agent_ip is not defined and total_private_ip_addresses is defined)
 
 - name: "Set default ip address for zabbix_agent_ip"
@@ -99,7 +99,7 @@
   fail:
     msg: "The specified network interface does not exist"
   when:
-    - zabbix_agent_listeninterface
+    - zabbix_agent_listeninterface | bool
     - (zabbix_agent_listeninterface not in ansible_all_ipv4_addresses)
   tags:
     - zabbix-agent
@@ -109,16 +109,16 @@
   set_fact:
     network_interface: ansible_{{ zabbix_agent_listeninterface }}
   when:
-    - zabbix_agent_listeninterface
-    - not zabbix_agent_listenip
+    - zabbix_agent_listeninterface | bool
+    - not (zabbix_agent_listenip | bool)
 
 - name: "Get IP of agent_listeninterface when no agent_listenip specified"
   set_fact:
     zabbix_agent_listenip: "{{ hostvars[inventory_hostname][network_interface]['ipv4'].address | default('0.0.0.0') }}"
     zabbix_agent_ip: "{{ hostvars[inventory_hostname][network_interface]['ipv4'].address | default('0.0.0.0') }}"
   when:
-    - zabbix_agent_listeninterface
-    - not zabbix_agent_listenip
+    - zabbix_agent_listeninterface | bool
+    - not (zabbix_agent_listenip | bool)
   tags:
     - zabbix-agent
     - config
@@ -128,7 +128,7 @@
   set_fact:
     zabbix_agent_listenip: '0.0.0.0'
   when:
-    - not zabbix_agent_listenip
+    - not (zabbix_agent_listenip | bool)
   tags:
     - zabbix-agent
     - config
@@ -152,7 +152,7 @@
 - name: "Install the correct repository"
   include: Linux.yml
   when:
-    - zabbix_agent_os_family != "Windows" or zabbix_agent_docker
+    - (zabbix_agent_os_family != "Windows") or (zabbix_agent_docker | bool)
 
 - name: "Installing the Zabbix-api package on localhost"
   pip:
@@ -163,8 +163,8 @@
   delegate_to: localhost
   become: "{{ zabbix_agent_become_on_localhost }}"
   when:
-    - zabbix_install_pip_packages
-    - zabbix_api_create_hostgroup or zabbix_api_create_hosts
+    - zabbix_install_pip_packages | bool
+    - (zabbix_api_create_hostgroup | bool) or (zabbix_api_create_hosts | bool)
 
 - name: "Create hostgroups"
   zabbix_group:
@@ -175,7 +175,7 @@
     state: "{{ zabbix_create_hostgroup }}"
     validate_certs: "{{ zabbix_validate_certs|default(omit) }}"
   when:
-    - zabbix_api_create_hostgroup
+    - zabbix_api_create_hostgroup | bool
   delegate_to: localhost
   become: no
   tags:
@@ -204,7 +204,7 @@
     tls_connect: "{{ zabbix_agent_tls_config[zabbix_agent_tlsconnect if zabbix_agent_tlsconnect else 'unencrypted'] }}"
     validate_certs: "{{ zabbix_validate_certs|default(omit) }}"
   when:
-    - zabbix_api_create_hosts
+    - zabbix_api_create_hosts | bool
   delegate_to: localhost
   become: no
   changed_when: false
@@ -222,7 +222,7 @@
     validate_certs: "{{ zabbix_validate_certs|default(omit) }}"
   with_items: "{{ zabbix_macros | default([]) }}"
   when:
-    - zabbix_api_create_hosts
+    - zabbix_api_create_hosts | bool
     - zabbix_macros is defined
     - item.macro_key is defined
   delegate_to: localhost


### PR DESCRIPTION
**Description of PR**
Fix warnings from ansible 2.8.
For apt: keep default bevavior with apt-get instead of aptitude.

**Type of change**
Bugfix Pull Request


