### PR TITLE
Added ansible_python_interpreter for Fedora

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,12 +26,14 @@ zabbix_repo_yum:
   - name: zabbix
     description: Zabbix Official Repository - $basearch
     baseurl: http://repo.zabbix.com/zabbix/{{ zabbix_version }}/rhel/{{ zabbix_agent_distribution_major_version }}/$basearch/
+    priority: 1
     gpgcheck: 0
     gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-ZABBIX
     state: present
   - name: zabbix-non-supported
     description: Zabbix Official Repository non-supported - $basearch
     baseurl: http://repo.zabbix.com/non-supported/rhel/{{ zabbix_agent_distribution_major_version }}/$basearch/
+    priority: 1
     gpgcheck: 0
     gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-ZABBIX
     state: present

--- a/molecule/before-last-version/molecule.yml
+++ b/molecule/before-last-version/molecule.yml
@@ -46,6 +46,9 @@ provisioner:
   lint:
     name: ansible-lint
   inventory:
+    host_vars:
+      zabbix-agent-fedora:
+        ansible_python_interpreter: /usr/bin/python3
     group_vars:
       all:
         zabbix_version: 4.0

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -49,6 +49,9 @@ provisioner:
   lint:
     name: ansible-lint
   inventory:
+    host_vars:
+      zabbix-agent-fedora:
+        ansible_python_interpreter: /usr/bin/python3
     group_vars:
       all:
         zabbix_agent_server: 192.168.3.33

--- a/molecule/with-server/molecule.yml
+++ b/molecule/with-server/molecule.yml
@@ -73,6 +73,8 @@ provisioner:
       docker:
         zabbix_agent_docker: True
     host_vars:
+      zabbix-agent-fedora:
+        ansible_python_interpreter: /usr/bin/python3
       zabbix-agent-ubuntu:
         zabbix_agent_tlsaccept: psk
         zabbix_agent_tlsconnect: psk

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -39,6 +39,7 @@
     baseurl: "{{ item.baseurl }}"
     gpgcheck: "{{ item.gpgcheck }}"
     gpgkey: "{{ item.gpgkey }}"
+    priority: "{{ item.priority | default('99') }}"
     state: "{{ item.state | default('present') }}"
   with_items: "{{ zabbix_repo_yum }}"
   register: yum_repo_installed


### PR DESCRIPTION
**Description of PR**
Default Python is 3 where Ansible would expect a python 2 installation. Specific for Fedora we set it to Python 3.

**Type of change**
<!--- Pick one below and delete the rest: -->

Bugfix Pull Request

**Fixes an issue**
<!--- If this PR fixes an issue, please mention it. -->
Fixes #237