### PR TITLE
Add "vars" tag to include variables

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,6 +17,7 @@
 - name: "Include OS-specific variables"
   include_vars: "{{ zabbix_agent_os_family }}.yml"
   tags:
+    - vars
     - zabbix-agent
 
 - name: "Install the correct repository"


### PR DESCRIPTION
**Description of PR**

Add `vars` tag to include variables.

**Type of change**

Add a new tag to include OS variables.

**Fixes an issue**

This fixes missing variables when using a tag not `zabbix-agent`, like `config` or `service`.
