### PR TITLE
Added INSERT iptables action instead of default APPEND

### DIFF
--- a/tasks/Linux.yml
+++ b/tasks/Linux.yml
@@ -108,6 +108,7 @@
 
 - name: "Configure IPTables (zabbix_agent_listenport)"
   iptables:
+    action: insert
     destination_port: "{{ zabbix_agent_listenport }}"
     source: "{{ zabbix_agent_firewall_source | default(omit) }}"
     protocol: tcp
@@ -118,6 +119,7 @@
 
 - name: "Configure IPTables (zabbix_agent_jmx_listenport)"
   iptables:
+    action: insert
     destination_port: "{{ zabbix_agent_listenport }}"
     source: "{{ zabbix_agent_firewall_source | default(omit) }}"
     protocol: tcp


### PR DESCRIPTION
**Description of PR**
By default module iptables uses action APPEND  which adds a rule in the end of rule's list.
Such rule will not work if it's added after `reject all traffic` rule. For example:

```
Chain INPUT (policy ACCEPT)
target     prot opt source               destination         
ACCEPT     all  --  0.0.0.0/0            0.0.0.0/0           state RELATED,ESTABLISHED 
ACCEPT     icmp --  0.0.0.0/0            0.0.0.0/0           
ACCEPT     all  --  0.0.0.0/0            0.0.0.0/0           
ACCEPT     tcp  --  0.0.0.0/0            0.0.0.0/0           state NEW tcp dpt:22 
REJECT     all  --  0.0.0.0/0            0.0.0.0/0           reject-with icmp-host-prohibited 
ACCEPT     tcp  --  0.0.0.0/0            0.0.0.0/0           tcp dpt:10050 
```

**Type of change**
Improvement
