### PR TITLE
Introduce AutoPSK for easy encryption; Closes dj-wasabi/ansible-zabbix-agent#250

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,9 +247,13 @@ These variables are specific for Zabbix 3.0 and higher:
 
 * `zabbix_agent_tlspskidentity`: Unique, case sensitive string used to identify the pre-shared key.
 
+* `zabbix_agent_tlspskidentity_file`: Full pathname of a file containing the pre-shared key identity.
+
 * `zabbix_agent_tlspskfile`: Full pathname of a file containing the pre-shared key.
 
 * `zabbix_agent_tlspsk_secret`: The pre-shared secret key that should be placed in the file configured with `agent_tlspskfile`.
+
+* `zabbix_agent_tlspsk_auto`: Enables auto generation and storing of individual pre-shared keys and identities on clients.
 
 ## Zabbix API variables
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -110,6 +110,7 @@ zabbix_agent_tlsservercertsubject:
 zabbix_agent_tlscertfile:
 zabbix_agent_tlskeyfile:
 zabbix_agent_tlspskidentity:
+zabbix_agent_tlspsk_auto: False
 
 zabbix_agent_tls_config:
   unencrypted: '1'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -149,8 +149,8 @@
   include_tasks: tlspsk_auto.yml
   when:
     - zabbix_agent_tlspsk_auto | bool
-    - (zabbix_agent_tlspskfile is undefined) or (zabbix_agent_tlspskfile == "")
-    - (zabbix_agent_tlspsk_secret is undefined) or (zabbix_agent_tlspsk_secret == "")
+    - (zabbix_agent_tlspskfile is undefined) or (zabbix_agent_tlspskfile | length == '0')
+    - (zabbix_agent_tlspsk_secret is undefined) or (zabbix_agent_tlspsk_secret | length == '0')
 
 - name: "Install the correct repository"
   include: Windows.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -145,6 +145,13 @@
     - zabbix-agent
     - config
 
+- name: "Encrypt with TLS PSK auto management"
+  include_tasks: tlspsk_auto.yml
+  when:
+    - zabbix_agent_tlspsk_auto | bool
+    - (zabbix_agent_tlspskfile is undefined) or (zabbix_agent_tlspskfile == "")
+    - (zabbix_agent_tlspsk_secret is undefined) or (zabbix_agent_tlspsk_secret == "")
+
 - name: "Install the correct repository"
   include: Windows.yml
   when:

--- a/tasks/tlspsk_auto.yml
+++ b/tasks/tlspsk_auto.yml
@@ -1,0 +1,78 @@
+---
+- name: AutoPSK | Set default path variables for Linux
+  set_fact:
+    zabbix_agent_tlspskfile: "/etc/zabbix/tls_psk_auto.secret"
+    zabbix_agent_tlspskidentity_file: "/etc/zabbix/tls_psk_auto.identity"
+  when: (zabbix_agent_os_family != "Windows") or (zabbix_agent_docker | bool)
+
+- name: AutoPSK | Set default path variables for Windows
+  set_fact:
+    zabbix_agent_tlspskfile: "{{ zabbix_win_install_dir }}\tls_psk_auto.secret.txt"
+    zabbix_agent_tlspskidentity_file: "{{ zabbix_win_install_dir }}\tls_psk_auto.identity.txt"
+  when: zabbix_agent_os_family == "Windows"
+
+- name: AutoPSK | Check for existing TLS PSK file
+  stat:
+    path: "{{ zabbix_agent_tlspskfile }}"
+  register: zabbix_agent_tlspskcheck
+
+- name: AutoPSK | read existing TLS PSK file
+  slurp:
+    src: "{{ zabbix_agent_tlspskfile }}"
+  register: zabbix_agent_tlspsk_base64
+  when: zabbix_agent_tlspskcheck.stat.exists
+
+- name: AutoPSK | Save existing TLS PSK secret
+  set_fact:
+    zabbix_agent_tlspsk_read: "{{ zabbix_agent_tlspsk_base64['content'] | b64decode | trim }}"
+  when: zabbix_agent_tlspskcheck.stat.exists
+
+- name: AutoPSK | Use existing TLS PSK secret
+  set_fact: 
+    zabbix_agent_tlspsk_secret: "{{ zabbix_agent_tlspsk_read }}"
+  when: zabbix_agent_tlspskcheck.stat.exists and zabbix_agent_tlspsk_read|length >= 32
+
+- name: AutoPSK | Generate new TLS PSK secret
+  set_fact: 
+    zabbix_agent_tlspsk_secret: "{{ lookup('password', '/dev/null chars=hexdigits length=64') }}"
+  when: not zabbix_agent_tlspskcheck.stat.exists or zabbix_agent_tlspsk_read|length < 32
+
+- name: AutoPSK | Check for existing TLS PSK identity
+  stat:
+    path: "{{ zabbix_agent_tlspskidentity_file }}"
+  register: zabbix_agent_tlspskidentity_check
+
+- name: AutoPSK | Read existing TLS PSK identity file
+  slurp:
+    src: "{{ zabbix_agent_tlspskidentity_file }}"
+  register: zabbix_agent_tlspskidentity_base64
+  when: zabbix_agent_tlspskidentity_check.stat.exists
+
+- name: AutoPSK | Use existing TLS PSK identity
+  set_fact: 
+    zabbix_agent_tlspskidentity: "{{ zabbix_agent_tlspskidentity_base64['content'] | b64decode | trim }}"
+  when: zabbix_agent_tlspskidentity_check.stat.exists
+
+- name: AutoPSK | Generate new TLS PSK identity
+  set_fact: 
+    zabbix_agent_tlspskidentity: "{{ zabbix_visible_hostname + '_' + lookup('password', '/dev/null chars=hexdigits length=4') }}"
+  when: not zabbix_agent_tlspskidentity_check.stat.exists
+
+- name: AutoPSK | Template TLS PSK identity in file
+  copy:
+    dest: "{{ zabbix_agent_tlspskidentity_file }}"
+    content: "{{ zabbix_agent_tlspskidentity }}"
+    owner: zabbix
+    group: zabbix
+    mode: 0400
+  when:
+    - zabbix_agent_tlspskidentity_file is defined
+    - zabbix_agent_tlspskidentity is defined
+  notify:
+    - restart zabbix-agent
+
+- name: AutoPSK | Default tlsaccept and tlsconnect to enforce PSK
+  set_fact:
+    zabbix_agent_tlsaccept: psk
+    zabbix_agent_tlsconnect: psk
+  when: zabbix_api_create_hosts

--- a/tasks/tlspsk_auto.yml
+++ b/tasks/tlspsk_auto.yml
@@ -28,12 +28,12 @@
   when: zabbix_agent_tlspskcheck.stat.exists
 
 - name: AutoPSK | Use existing TLS PSK secret
-  set_fact: 
+  set_fact:
     zabbix_agent_tlspsk_secret: "{{ zabbix_agent_tlspsk_read }}"
   when: zabbix_agent_tlspskcheck.stat.exists and zabbix_agent_tlspsk_read|length >= 32
 
 - name: AutoPSK | Generate new TLS PSK secret
-  set_fact: 
+  set_fact:
     zabbix_agent_tlspsk_secret: "{{ lookup('password', '/dev/null chars=hexdigits length=64') }}"
   when: not zabbix_agent_tlspskcheck.stat.exists or zabbix_agent_tlspsk_read|length < 32
 
@@ -49,12 +49,12 @@
   when: zabbix_agent_tlspskidentity_check.stat.exists
 
 - name: AutoPSK | Use existing TLS PSK identity
-  set_fact: 
+  set_fact:
     zabbix_agent_tlspskidentity: "{{ zabbix_agent_tlspskidentity_base64['content'] | b64decode | trim }}"
   when: zabbix_agent_tlspskidentity_check.stat.exists
 
 - name: AutoPSK | Generate new TLS PSK identity
-  set_fact: 
+  set_fact:
     zabbix_agent_tlspskidentity: "{{ zabbix_visible_hostname + '_' + lookup('password', '/dev/null chars=hexdigits length=4') }}"
   when: not zabbix_agent_tlspskidentity_check.stat.exists
 


### PR DESCRIPTION
**Description of PR**
Heavily inspired by our precious work on integrating Let's Encrypt and pushing certbot backporting this aims to be a dead simple solutions aiming for security KISSes. We basically use local filesystem where the Zabbix agent runs to store there two individual files with PSK and ID so the credentials stay only where they are needed anyway. But on every run we parse them for distributing them to the Zabbix server via the `zabbix_host` module.

This way the user of this rule just needs to toggle `zabbix_agent_tlspsk_auto` for enabling encryption between all the agents and the server. Ansible delivers here we're currently fail with Zabbix as both auto registration and network discovery are not usable with encryption.

**Type of change**
Feature Pull Request

**Fixes an issue**
dj-wasabi/ansible-zabbix-agent#250
