### PR TITLE
Add Debian 10 (buster) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ See the following list of supported Operating systems with the Zabbix releases:
   * OracleLinux 7.x
   * Scientific Linux 7.x
   * Ubuntu 14.04, 16.04, 18.04
-  * Debian 8, 9
+  * Debian 8, 9, 10
 
 ### Zabbix 4.0
 
@@ -96,7 +96,7 @@ See the following list of supported Operating systems with the Zabbix releases:
   * OracleLinux 7.x
   * Scientific Linux 7.x
   * Ubuntu 14.04, 16.04, 18.04
-  * Debian 8, 9
+  * Debian 8, 9, 10
 
 ### Zabbix 3.4
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -22,6 +22,7 @@ galaxy_info:
       versions:
         - squeeze
         - wheezy
+        - jessie
         - stretch
     - name: opensuse
       versions:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -24,6 +24,7 @@ galaxy_info:
         - wheezy
         - jessie
         - stretch
+        - buster
     - name: opensuse
       versions:
         - 12.1

--- a/vars/zabbix.yml
+++ b/vars/zabbix.yml
@@ -16,6 +16,8 @@ sign_keys:
       sign_key: 79EA5ED4
     jessie:
       sign_key: 79EA5ED4
+    buster:
+      sign_key: 79EA5ED4
     trusty:
       sign_key: 79EA5ED4
     xenial:
@@ -34,6 +36,8 @@ sign_keys:
     wheezy:
       sign_key: 79EA5ED4
     jessie:
+      sign_key: 79EA5ED4
+    buster:
       sign_key: 79EA5ED4
     trusty:
       sign_key: 79EA5ED4

--- a/vars/zabbix.yml
+++ b/vars/zabbix.yml
@@ -16,8 +16,6 @@ sign_keys:
       sign_key: 79EA5ED4
     jessie:
       sign_key: 79EA5ED4
-    buster:
-      sign_key: 79EA5ED4
     trusty:
       sign_key: 79EA5ED4
     xenial:
@@ -36,8 +34,6 @@ sign_keys:
     wheezy:
       sign_key: 79EA5ED4
     jessie:
-      sign_key: 79EA5ED4
-    buster:
       sign_key: 79EA5ED4
     trusty:
       sign_key: 79EA5ED4


### PR DESCRIPTION
**Description of PR**
This adds support for Debian 10 (buster) servers.
Buster is Debian Stable since 2019-07-06.

**Type of change**
Feature Pull Request

**Fixes an issue**
