### PR TITLE
Add support for firewalld zone

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,8 @@ Keep in mind that using the Zabbix Agent in a Container, requires changes to the
 
 * `zabbix_agent_firewalld_source`: When provided, firewalld will be configuring to only allow traffic for IP configured in `zabbix_agent_server`.
 
+* `zabbix_agent_firewalld_zone`: When provided, the firewalld rule will be attached to this zone (only if zabbix_agent_firewalld_enable is set to true). The default behavior is to use the default zone define by the remote host firewalld configuration.
+
 # Dependencies
 
 There are no dependencies on other roles.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -67,7 +67,7 @@ zabbix_agent_interfaces:
 zabbix_agent_firewall_enable: False
 zabbix_agent_firewalld_enable: False
 zabbix_agent_firewalld_source: "{{ zabbix_agent_server }}"
-# By default, a null zone will trigger the use of the default zone on the remote host 
+# By default, a null zone will trigger the use of the default zone on the remote host
 zabbix_agent_firewalld_zone:
 # Zabbix configuration variables
 zabbix_agent_pidfile: /var/run/zabbix/zabbix_agentd.pid

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -67,6 +67,8 @@ zabbix_agent_interfaces:
 zabbix_agent_firewall_enable: False
 zabbix_agent_firewalld_enable: False
 zabbix_agent_firewalld_source: "{{ zabbix_agent_server }}"
+# By default, a null zone will trigger the use of the default zone on the remote host 
+zabbix_agent_firewalld_zone:
 # Zabbix configuration variables
 zabbix_agent_pidfile: /var/run/zabbix/zabbix_agentd.pid
 zabbix_agent_logfile: /var/log/zabbix/zabbix_agentd.log

--- a/tasks/Linux.yml
+++ b/tasks/Linux.yml
@@ -129,6 +129,7 @@
 - name: "Configure firewalld (zabbix_agent_listenport)"
   firewalld:
     rich_rule: 'rule family="ipv4" source address="{{ zabbix_agent_firewalld_source }}" port protocol="tcp" port="{{ zabbix_agent_listenport }}" accept'
+    zone: "{{ zabbix_agent_firewalld_zone }}"
     permanent: true
     state: enabled
   become: yes
@@ -140,6 +141,7 @@
 - name: "Configure firewalld (zabbix_agent_jmx_listenport)"
   firewalld:
     rich_rule: 'rule family="ipv4" source address="{{ zabbix_agent_firewalld_source }}" port protocol="tcp" port="{{ zabbix_agent_jmx_listenport }}" accept'
+    zone: "{{ zabbix_agent_firewalld_zone }}"
     permanent: true
     state: enabled
   become: yes


### PR DESCRIPTION
**Description of PR**
<!--- Describe what the PR holds -->
This PR add a new feature to support the configuration of the zone for the firewalld rich rule when using `zabbix_agent_firewalld_enable: true`.

**Type of change**
<!--- Pick one below and delete the rest: -->
Feature Pull Request

**Fixes an issue**
<!--- If this PR fixes an issue, please mention it. -->
Fixes Feature request #260 