### PR TITLE
According to #263 1100 needs to be added to the sc.exe call

### DIFF
--- a/tasks/Windows.yml
+++ b/tasks/Windows.yml
@@ -126,7 +126,7 @@
     state: started
 
 - name: "Windows | Getting Zabbix Service Recovery Settings"
-  win_shell: sc.exe qfailure "Zabbix Agent"
+  win_shell: sc.exe qfailure "Zabbix Agent" 1100
   register: svc_recovery
   changed_when: false
   when: zabbix_agent_win_svc_recovery


### PR DESCRIPTION
**Description of PR**
Fix: Role fails to get zabbix service recovery settings when run against Windows

**Type of change**
<!--- Pick one below and delete the rest: -->

Bugfix Pull Request

**Fixes an issue**

Fixes:  #263
