### PR TITLE
Pass params to Ansible Zabbix modules used by role to allow HTTP Basi…

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,9 @@ When `zabbix_api_create_hostgroup` or `zabbix_api_create_hosts` is set to `True`
 
 * `zabbix_url`: The url on which the Zabbix webpage is available. Example: http://zabbix.example.com
 
+* `zabbix_api_http_user`: The http user to access zabbix url with Basic Auth
+* `zabbix_api_http_password`: The http password to access zabbix url with Basic Auth
+
 * `zabbix_api_create_hosts`: When you want to enable the Zabbix API to create/delete the host. This has to be set to `True` if you want to make use of `zabbix_create_host`. Default: `False`
 
 * `zabbix_api_create_hostgroup`: When you want to enable the Zabbix API to create/delete the hostgroups. This has to be set to `True` if you want to make use of `zabbix_create_hostgroup`.Default: `False`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,6 +40,8 @@ zabbix_repo_yum:
 
 # Zabbix API stuff
 zabbix_url: "http://zabbix.dj-wasabi.local"
+# zabbix_api_http_user: admin
+# zabbix_api_http_password: admin
 zabbix_api_user: Admin
 zabbix_api_pass: zabbix
 zabbix_api_create_hostgroup: False

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -108,6 +108,8 @@
 - name: "Create hostgroups"
   zabbix_group:
     server_url: "{{ zabbix_url }}"
+    http_login_user: "{{ zabbix_api_http_user | default(omit) }}"
+    http_login_password: "{{ zabbix_api_http_password | default(omit) }}"
     login_user: "{{ zabbix_api_user }}"
     login_password: "{{ zabbix_api_pass }}"
     host_group: "{{ zabbix_host_groups }}"
@@ -125,6 +127,8 @@
 - name: "Create a new host or update an existing host's info"
   zabbix_host:
     server_url: "{{ zabbix_url }}"
+    http_login_user: "{{ zabbix_api_http_user | default(omit) }}"
+    http_login_password: "{{ zabbix_api_http_password | default(omit) }}"
     login_user: "{{ zabbix_api_user }}"
     login_password: "{{ zabbix_api_pass }}"
     host_name: "{{ zabbix_agent_hostname }}"
@@ -157,6 +161,8 @@
 - name: "Updating host configuration with macros"
   zabbix_hostmacro:
     server_url: "{{ zabbix_url }}"
+    http_login_user: "{{ zabbix_api_http_user | default(omit) }}"
+    http_login_password: "{{ zabbix_api_http_password | default(omit) }}"
     login_user: "{{ zabbix_api_user }}"
     login_password: "{{ zabbix_api_pass }}"
     host_name: "{{ zabbix_agent_hostname }}"


### PR DESCRIPTION
Hi, here is an humble contribution to add params available on Ansible zabbix modules to give HTTP Basic credentials when calling API url. Hope this can be usefull for someone else.

However, I run _molecule test_ to check if everything is good but I had a small error with this task https://github.com/nadley/ansible-zabbix-agent/blob/master/tasks/main.yml#L67. It was complaining about Sudo password of my local user on my desktop, but I haven't found any option to pass the Sudo password. I'm going to dig this problem until that hope this PR will not break anything.

Regards,

**Description of PR**
Add support for HTTP Basic Auth on Zabbix API Url

**Type of change**
Feature Pull Request