### PR TITLE
Add follow_redirects for download Windows-Agent on Windows

### DIFF
--- a/tasks/Windows.yml
+++ b/tasks/Windows.yml
@@ -105,6 +105,7 @@
     url: "{{ zabbix_win_download_link }}"
     dest: '{{ zabbix_win_install_dir }}\{{ zabbix_win_package }}'
     force: False
+    follow_redirects: all
   environment:
     http_proxy: "{{ zabbix_http_proxy | default(None) | default(omit) }}"
     https_proxy: "{{ zabbix_https_proxy | default(None) | default(omit) }}"


### PR DESCRIPTION
Description of PR :
Zabbix has set up a redirection to download the zabbix agents for Windows:
(Example with version 3.4.6)
https://www.zabbix.com/downloads/3.4.6/zabbix_agents_3.4.6.win.zip => https://assets.zabbix.com/downloads/3.4.6/zabbix_agents_3.4.6.win.zip

    },
    "msg": "Moved Temporarily",
    "size": 154,
    "status_code": 302,
    "url": "https://www.zabbix.com/downloads/3.4.6/zabbix_agents_3.4.6.win.zip"
}

Here is the problem encountered : 
TASK [dj-wasabi.zabbix-agent : Windows | Unzip file] *****************************************************************************************************************************************************************************************
fatal: [hostname]: FAILED! => {
    "changed": false,
    "dest": "C:\\Zabbix",
    "msg": "Error unzipping 'C:\\Zabbix\\zabbix_agents_3.4.6.win.zip' to 'C:\\Zabbix'!. Method: System.IO.Compression.ZipFile, Exception: Exception calling \"Open\" with \"3\" argument(s): \"End of Central Directory record could not be found.\"",
    "removed": false,
    "src": "C:\\Zabbix\\zabbix_agents_3.4.6.win.zip"
}

It is not possible to unzip the file because it has not been downloaded correctly.

The goal of this PR is to adapt the playbook to be able to download the zabbix agents with this redirection.

Type of change :
Add "follow_redirects: all" to the task : Windows | Download Zabbix Agent Zip file