### PR TITLE
'Template OS Linux' doesn't exist in Zabbix 4.4

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -56,7 +56,7 @@ zabbix_useuip: 1
 zabbix_host_groups:
   - Linux servers
 zabbix_link_templates:
-  - Template OS Linux
+  - Template OS Linux by Zabbix agent
 
 zabbix_agent_interfaces:
   - type: 1


### PR DESCRIPTION
Chaging value of zabbix_link_templates property as 'Template OS Linux' doesn't exist in Zabbix 4.4

**Description of PR**
<!--- Describe what the PR holds -->

**Type of change**
<!--- Pick one below and delete the rest: -->

Bugfix Pull Request

**Fixes an issue**
<!--- If this PR fixes an issue, please mention it. -->
