### PR TITLE
Implement support for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ This role will work on the following operating systems:
  * Ubuntu
  * opensuse
  * Windows (Best effort)
+ * macOS
 
 So, you'll need one of those operating systems.. :-)
 Please sent Pull Requests or suggestions when you want to use this role for other Operating systems.
@@ -89,6 +90,7 @@ See the following list of supported Operating systems with the Zabbix releases:
   * Scientific Linux 7.x, 8.x
   * Ubuntu 14.04, 16.04, 18.04
   * Debian 8, 9, 10
+  * macOS 10.14, 10.15
 
 ### Zabbix 4.2
 
@@ -100,6 +102,7 @@ See the following list of supported Operating systems with the Zabbix releases:
   * Scientific Linux 7.x
   * Ubuntu 14.04, 16.04, 18.04
   * Debian 8, 9, 10
+  * macOS 10.14, 10.15
 
 ### Zabbix 4.0
 
@@ -111,6 +114,7 @@ See the following list of supported Operating systems with the Zabbix releases:
   * Scientific Linux 7.x
   * Ubuntu 14.04, 16.04, 18.04
   * Debian 8, 9, 10
+  * macOS 10.14, 10.15
 
 ### Zabbix 3.4
 
@@ -337,6 +341,12 @@ _Supporting Windows is a best effort (I don't have the possibility to either tes
 * `zabbix_agent_win_include`: The directory in which the Zabbix specific configuration files are stored.
 
 * `zabbix_agent_win_svc_recovery`: Enable Zabbix Agent service auto-recovery settings.
+
+## macOS Variables
+
+* `zabbix_version_long`: The long (major.minor.patch) version of the Zabbix Agent. This will be used to generate the `zabbix_mac_download_link` link.
+
+* `zabbix_mac_download_link`: The download url to the `pkg` file.
 
 ## Docker Variables
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -125,8 +125,10 @@ zabbix_agent_tls_config:
   psk: '2'
   cert: '4'
 
+# Windows/macOS Related
+zabbix_version_long: 4.4.4
+
 # Windows Related
-zabbix_version_long: 4.2.0
 zabbix_win_package: zabbix_agents_{{ zabbix_version_long }}.win.zip
 zabbix_win_download_url: https://www.zabbix.com/downloads
 zabbix_win_download_link: "{{ zabbix_win_download_url }}/{{ zabbix_version_long }}/{{ zabbix_win_package }}"
@@ -134,6 +136,11 @@ zabbix_win_install_dir: 'C:\Zabbix'
 zabbix_agent_win_logfile: 'C:\Zabbix\zabbix_agentd.log'
 zabbix_agent_win_include: 'C:\Zabbix\zabbix_agent.d\'
 zabbix_agent_win_svc_recovery: True
+
+# macOS Related
+zabbix_mac_package: zabbix_agent-{{ zabbix_version_long }}-macos-amd64-openssl.pkg
+zabbix_mac_download_url: https://www.zabbix.com/downloads
+zabbix_mac_download_link: "{{ zabbix_mac_download_url }}/{{ zabbix_version_long }}/{{ zabbix_mac_package }}"
 
 # Zabbix Agent Docker facts
 zabbix_agent_docker: False

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -9,6 +9,7 @@
   become: yes
   when:
     - not zabbix_agent_docker
+    - zabbix_agent_os_family != "Windows" and zabbix_agent_os_family != "Darwin"
 
 - name: firewalld-reload
   command: "firewall-cmd --reload"
@@ -18,3 +19,12 @@
     name: "{{ zabbix_win_agent_service }}"
     state: restarted
     enabled: yes
+  when:
+    - zabbix_agent_os_family == "Windows"
+
+- name: restart mac zabbix agent
+  command: "launchctl kickstart -k system/{{ zabbix_agent_service }}"
+  become: true
+  when:
+    - not zabbix_agent_docker
+    - zabbix_agent_os_family == "Darwin"

--- a/tasks/Darwin.yml
+++ b/tasks/Darwin.yml
@@ -147,10 +147,13 @@
     - zabbix_agent_docker | bool
 
 - name: "Check if zabbix-agent service is running"
-  shell: "launchctl list | grep com.zabbix.zabbix_agentd | awk '{print $1}'"
+  shell: |
+    set -o pipefail
+    launchctl list | grep com.zabbix.zabbix_agentd | awk '{print $1}'
   register: launchctl_pid
   check_mode: no
   changed_when: false
+  failed_when: launchctl_pid.rc == 2
   become: yes
   tags:
     - init

--- a/tasks/Darwin.yml
+++ b/tasks/Darwin.yml
@@ -1,0 +1,167 @@
+---
+
+- name: "Set default ip address for zabbix_agent_ip"
+  set_fact:
+    zabbix_agent_ip: "{{ hostvars[inventory_hostname]['ansible_default_ipv4'].address }}"
+  when:
+    - zabbix_agent_ip is not defined
+    - "'ansible_default_ipv4' in hostvars[inventory_hostname]"
+
+- name: "Get Total Private IP Addresses"
+  set_fact:
+    total_private_ip_addresses: "{{ ansible_all_ipv4_addresses | ipaddr('private') | length }}"
+  when:
+    - ansible_all_ipv4_addresses is defined
+
+- name: "Set first public ip address for zabbix_agent_ip"
+  set_fact:
+    zabbix_agent_ip: "{{ ansible_all_ipv4_addresses | ipaddr('public') | first }}"
+    zabbix_agent_server: "{{ zabbix_agent_server_public_ip | default(zabbix_agent_server) }}"
+    zabbix_agent_serveractive: "{{ zabbix_agent_serveractive_public_ip | default(zabbix_agent_serveractive) }}"
+  when:
+    - zabbix_agent_ip is not defined
+    - total_private_ip_addresses is defined
+    - total_private_ip_addresses == '0'
+
+- name: "Set first private ip address for zabbix_agent_ip"
+  set_fact:
+    zabbix_agent_ip: "{{ ansible_all_ipv4_addresses | ipaddr('private') | first }}"
+  when:
+    - zabbix_agent_ip is not defined
+    - total_private_ip_addresses is defined
+    - total_private_ip_addresses != '0'
+
+- name: "Fail invalid specified agent_listeninterface"
+  fail:
+    msg: "The specified network interface does not exist"
+  when:
+    - zabbix_agent_listeninterface
+    - (zabbix_agent_listeninterface not in ansible_all_ipv4_addresses)
+  tags:
+    - zabbix-agent
+    - config
+
+- name: "Set network interface"
+  set_fact:
+    network_interface: ansible_{{ zabbix_agent_listeninterface }}
+  when:
+    - zabbix_agent_listeninterface
+    - not zabbix_agent_listenip
+
+- name: "Get IP of agent_listeninterface when no agent_listenip specified"
+  set_fact:
+    zabbix_agent_listenip: "{{ hostvars[inventory_hostname][network_interface]['ipv4'].address | default('0.0.0.0') }}"
+    zabbix_agent_ip: "{{ hostvars[inventory_hostname][network_interface]['ipv4'].address | default('0.0.0.0') }}"
+  when:
+    - zabbix_agent_listeninterface
+    - not zabbix_agent_listenip
+  tags:
+    - zabbix-agent
+    - config
+    - api
+
+- name: "Default agent_listenip to all when not specified"
+  set_fact:
+    zabbix_agent_listenip: '0.0.0.0'
+  when:
+    - not zabbix_agent_listenip
+  tags:
+    - zabbix-agent
+    - config
+
+- name: "Fail invalid specified agent_listenip"
+  fail:
+    msg: "The agent_listenip does not exist"
+  when:
+    - zabbix_agent_listenip != '0.0.0.0'
+    - zabbix_agent_listenip != '127.0.0.1'
+    - (zabbix_agent_listenip not in ansible_all_ipv4_addresses)
+  tags:
+    - zabbix-agent
+    - config
+
+- name: "Configure zabbix-agent"
+  template:
+    src: zabbix_agentd.conf.j2
+    dest: "/usr/local/etc/zabbix/{{ zabbix_agent_conf }}"
+    owner: root
+    group: wheel
+    mode: 0644
+  notify:
+    - restart mac zabbix agent
+  become: yes
+  when:
+    - not (zabbix_agent_docker | bool)
+  tags:
+    - zabbix-agent
+    - config
+    - init
+
+- name: "Create directory for PSK file if not exist."
+  file:
+    path: "{{ zabbix_agent_tlspskfile | dirname }}"
+    mode: 0755
+    state: directory
+  become: yes
+  when:
+    - zabbix_agent_tlspskfile is defined
+
+- name: "Place TLS PSK File"
+  copy:
+    dest: "{{ zabbix_agent_tlspskfile }}"
+    content: "{{ zabbix_agent_tlspsk_secret }}"
+    owner: zabbix
+    group: zabbix
+    mode: 0400
+  become: yes
+  when:
+    - zabbix_agent_tlspskfile is defined
+    - zabbix_agent_tlspsk_secret is defined
+  notify:
+    - restart mac zabbix agent
+
+- name: "Create include dir zabbix-agent"
+  file:
+    path: "{{ zabbix_agent_include }}"
+    owner: root
+    group: zabbix
+    mode: 0750
+    state: directory
+  become: yes
+  tags:
+    - config
+    - include
+
+- name: "Create pid file directory for zabbix-agent"
+  file:
+    path: /var/run/zabbix
+    state: directory
+    owner: zabbix
+    group: zabbix
+    mode: 0755
+  become: yes
+
+- name: "Install the Docker container"
+  include: Docker.yml
+  when:
+    - zabbix_agent_docker | bool
+
+- name: "Check if zabbix-agent service is running"
+  shell: "launchctl list | grep com.zabbix.zabbix_agentd | awk '{print $1}'"
+  register: launchctl_pid
+  check_mode: no
+  changed_when: false
+  become: yes
+  tags:
+    - init
+    - service
+
+- name: "Make sure the zabbix-agent service is running"
+  command: launchctl start com.zabbix.zabbix_agentd
+  become: yes
+  when:
+    - not (zabbix_agent_docker | bool)
+    - launchctl_pid.stdout == "-"
+  tags:
+    - init
+    - service

--- a/tasks/macOS.yml
+++ b/tasks/macOS.yml
@@ -1,0 +1,21 @@
+---
+# Tasks specific for macOS
+- name: "macOS | Check installed package version"
+  shell: "pkgutil --pkg-info 'com.zabbix.pkg.ZabbixAgent' | grep 'version:' | cut -d ' ' -f 2"
+  register: pkgutil_version
+  check_mode: no
+  changed_when: false
+
+- name: "macOS | Download the Zabbix package"
+  get_url:
+    url: "{{ zabbix_mac_download_link }}"
+    dest: "/tmp/{{ zabbix_mac_package }}"
+    mode: 0644
+  when: pkgutil_version.stdout != zabbix_version_long
+
+- name: "macOS | Install the Zabbix package"
+  command: installer -pkg "/tmp/{{ zabbix_mac_package }}" -target /
+  become: true
+  when: pkgutil_version.stdout != zabbix_version_long
+  tags:
+    - zabbix-agent

--- a/tasks/macOS.yml
+++ b/tasks/macOS.yml
@@ -1,10 +1,13 @@
 ---
 # Tasks specific for macOS
 - name: "macOS | Check installed package version"
-  shell: "pkgutil --pkg-info 'com.zabbix.pkg.ZabbixAgent' | grep 'version:' | cut -d ' ' -f 2"
+  shell: |
+    set -o pipefail
+    pkgutil --pkg-info 'com.zabbix.pkg.ZabbixAgent' | grep 'version:' | cut -d ' ' -f 2
   register: pkgutil_version
   check_mode: no
   changed_when: false
+  failed_when: pkgutil_version.rc == 2
 
 - name: "macOS | Download the Zabbix package"
   get_url:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -57,7 +57,12 @@
 - name: "Install the correct repository"
   include_tasks: Linux.yml
   when:
-    - (zabbix_agent_os_family != "Windows") or (zabbix_agent_docker | bool)
+    - (zabbix_agent_os_family != "Windows" and zabbix_agent_os_family != "Darwin") or (zabbix_agent_docker | bool)
+
+- name: "Install the correct repository"
+  include_tasks: macOS.yml
+  when:
+    - zabbix_agent_os_family == "Darwin"
 
 - name: "Installing the Zabbix-api package on localhost"
   pip:

--- a/tasks/tlspsk_auto.yml
+++ b/tasks/tlspsk_auto.yml
@@ -70,6 +70,8 @@
     - zabbix_agent_tlspskidentity is defined
   notify:
     - restart zabbix-agent
+    - restart win zabbix-agent
+    - restart mac zabbix agent
 
 - name: AutoPSK | Default tlsaccept and tlsconnect to enforce PSK
   set_fact:

--- a/tasks/userparameter.yml
+++ b/tasks/userparameter.yml
@@ -7,7 +7,10 @@
     owner: zabbix
     group: zabbix
     mode: 0644
-  notify: restart zabbix-agent
+  notify:
+    - restart zabbix-agent
+    - restart win zabbix-agent
+    - restart mac zabbix agent
   become: yes
   with_items: "{{ zabbix_agent_userparameters }}"
 
@@ -18,7 +21,10 @@
     owner: zabbix
     group: zabbix
     mode: 0755
-  notify: restart zabbix-agent
+  notify:
+    - restart zabbix-agent
+    - restart win zabbix-agent
+    - restart mac zabbix agent
   become: yes
   with_items: "{{ zabbix_agent_userparameters }}"
   when: item.scripts_dir is defined

--- a/vars/Darwin.yml
+++ b/vars/Darwin.yml
@@ -1,0 +1,6 @@
+---
+# vars file for zabbix-agent (Debian)
+
+zabbix_agent: zabbix-agent
+zabbix_agent_service: com.zabbix.zabbix_agentd
+zabbix_agent_conf: zabbix_agentd.conf


### PR DESCRIPTION
**Description of PR**

This PR implements support for macOS. I've tested the changes with Zabbix 4.4.4 and macOS 10.14. In my tests the role was able to successfully install and configure the Zabbix agent.

I've also bumped the version for `zabbix_version_long` to 4.4.4, because I figured that re-using that variable for macOS would make sense. The version change might affect Windows.

The PR also ensures that the Zabbix agent is restarted after PSK and user parameter changes. This previously didn't work on Windows (see `tasks/tlspsk_auto.yml` and `tasks/userparameter.yml`).

**Type of change**

Feature Pull Request