### PR TITLE
Fix incorrect handler names

### DIFF
--- a/tasks/tlspsk_auto.yml
+++ b/tasks/tlspsk_auto.yml
@@ -70,7 +70,7 @@
     - zabbix_agent_tlspskidentity is defined
   notify:
     - restart zabbix-agent
-    - restart win zabbix-agent
+    - restart win zabbix agent
     - restart mac zabbix agent
 
 - name: AutoPSK | Default tlsaccept and tlsconnect to enforce PSK

--- a/tasks/userparameter.yml
+++ b/tasks/userparameter.yml
@@ -9,7 +9,7 @@
     mode: 0644
   notify:
     - restart zabbix-agent
-    - restart win zabbix-agent
+    - restart win zabbix agent
     - restart mac zabbix agent
   become: yes
   with_items: "{{ zabbix_agent_userparameters }}"
@@ -23,7 +23,7 @@
     mode: 0755
   notify:
     - restart zabbix-agent
-    - restart win zabbix-agent
+    - restart win zabbix agent
     - restart mac zabbix agent
   become: yes
   with_items: "{{ zabbix_agent_userparameters }}"


### PR DESCRIPTION
**Description of PR**

This PR fixes incorrect handler names which I broke in #298.

**Type of change**

Bugfix Pull Request

**Fixes an issue**

```
TASK [dj-wasabi.zabbix-agent : Installing user-defined userparameters] ***********************************************************************************************************************************************************************
changed: [ztest] => (item={'name': 'zfs'})
ERROR! The requested handler 'restart win zabbix-agent' was not found in either the main handlers list nor in the listening handlers list
```