### PR TITLE
Avoid conflicts with the zabbix_version and zabbix_url variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,11 +180,11 @@ This will install the zabbix-agent role into your `roles` directory.
 
 In order to get the Zabbix Agent running, you'll have to define the following properties before executing the role:
 
-* zabbix_version
+* zabbix_agent_version
 * zabbix_agent_server
 * zabbix_agent_serveractive (When using active checks)
 
-The `zabbix_version` is optional. The latest available major.minor version of Zabbix will be installed on the host(s). If you want to use an older version, please specify this in the major.minor format. Example: `zabbix_version: 4.0`, `zabbix_version: 3.4` or `zabbix_version: 2.2`.
+The `zabbix_agent_version` is optional. The latest available major.minor version of Zabbix will be installed on the host(s). If you want to use an older version, please specify this in the major.minor format. Example: `zabbix_agent_version: 4.0`, `zabbix_agent_version: 3.4` or `zabbix_agent_version: 2.2`.
 
 The `zabbix_agent_server` (and `zabbix_agent_serveractive`) should contain the ip or fqdn of the host running the Zabbix Server.
 
@@ -202,7 +202,7 @@ There are some variables in default/main.yml which can (or need to) be overridde
 
 * `zabbix_agent_serveractive`: The ip address for the zabbix-server or zabbix-proxy for active checks.
 
-* `zabbix_version`: This is the version of zabbix. Default it is 4.0, but can be overridden to one of the versions mentioned in [Zabbix Versions](#zabbix-versions).
+* `zabbix_agent_version`: This is the version of zabbix. Default it is 4.4, but can be overridden to one of the versions mentioned in [Zabbix Versions](#zabbix-versions). Previously the variable `zabbix_version` was used directly but it could cause [some inconvenience](https://github.com/dj-wasabi/ansible-zabbix-agent/pull/303). That variable is maintained by retrocompativility.
 
 * `zabbix_repo`: Default: _zabbix_
   * _epel_ install agent from EPEL repo

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,8 @@
 ---
 # defaults file for zabbix-agent
 
-zabbix_version: 4.4
+zabbix_agent_version: 4.4
+zabbix_version: "{{ zabbix_agent_version }}"
 zabbix_version_patch: 0
 zabbix_repo: zabbix
 zabbix_agent_package: zabbix-agent
@@ -39,7 +40,8 @@ zabbix_repo_yum:
     state: present
 
 # Zabbix API stuff
-zabbix_url: "http://zabbix.dj-wasabi.local"
+zabbix_agent_server_url: "http://zabbix.dj-wasabi.local"
+zabbix_url: "{{ zabbix_agent_server_url }}"
 # zabbix_api_http_user: admin
 # zabbix_api_http_password: admin
 zabbix_api_user: Admin


### PR DESCRIPTION
**Feature Pull Request**

Hello again,

currently the version of the Zabbix Agent to be installed is indicated by a variable (`zabbix_version`) that has the same name in this role, in [zabbix-server](https://github.com/dj-wasabi/ansible-zabbix-server) and in [zabbix-web](https://github.com/dj-wasabi/ansible-zabbix-web).

This generates some collisions when all roles are used on the same host or group of hosts (the most frequently used case) and makes it impossible to have different agent and server versions (it is necessary in some cases).

This pull request is a solution to this problem, while maintaining backward compatibility with the current variable structure. It's simply proposed to use a new variable, `zabbix_agent_version`, to indicate the version of the agent to be installed and use this variable as a "bypass" for the variable used by the role:
```yaml
zabbix_agent_version: 4.4
zabbix_version: "{{ zabbix_agent_version }}"
```

Identical reasoning is applied to the variable `zabbix_url`, which can also result in conflicts with the other Zabbix roles
```yaml
zabbix_agent_server_url: "http://zabbix.dj-wasabi.local"
zabbix_url: "{{ zabbix_agent_server_url }}"
```

Naturally, to maintain consistency throughout the role kit, the same "bypass" must be performed on `zabbix-server` and `zabbix-web`. This pull request is accompanied by two others that I am sending you in minutes.