### PR TITLE
Move up task 'Override architecture if 64-bit'

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -129,7 +129,7 @@ zabbix_agent_tls_config:
 zabbix_version_long: 4.4.4
 
 # Windows Related
-zabbix_win_package: zabbix_agents_{{ zabbix_version_long }}.win.zip
+zabbix_win_package: zabbix_agent-{{ zabbix_version_long }}-windows-i386.zip
 zabbix_win_download_url: https://www.zabbix.com/downloads
 zabbix_win_download_link: "{{ zabbix_win_download_url }}/{{ zabbix_version_long }}/{{ zabbix_win_package }}"
 zabbix_win_install_dir: 'C:\Zabbix'

--- a/tasks/Windows.yml
+++ b/tasks/Windows.yml
@@ -11,6 +11,12 @@
   set_fact:
     windows_arch: 32
 
+- name: "Windows | Override architecture if 64-bit"
+  set_fact:
+    windows_arch: 64
+  when:
+    - ansible_architecture == "64-bit"
+
 - name: "Windows | Set path to zabbix.exe"
   set_fact:
     zabbix_win_exe_path: '{{ zabbix_win_install_dir }}\bin\win{{ windows_arch }}\zabbix_agentd.exe'
@@ -21,12 +27,6 @@
     zabbix_win_exe_path: '{{ zabbix_win_install_dir }}\bin\zabbix_agentd.exe'
   when:
     - zabbix_version_long is version('4.0.0', '>=')
-
-- name: "Windows | Override architecture if 64-bit"
-  set_fact:
-    windows_arch: 64
-  when:
-    - ansible_architecture == "64-bit"
 
 - name: "Windows | Check if Zabbix agent is present"
   win_stat:


### PR DESCRIPTION
**Description of PR**
Move up task 'Override architecture if 64-bit'
The fact 'windows_arch' is set to 32 per default line 10. 
The fact 'windows_arch' is used by "Windows | Set path to zabbix.exe" task juste after, so the path zabbix_win_exe_path contain 32bit path. And the override is after.
If we keep the override set_fact after this task : the path 'zabbix_win_exe_path' is not changed and keep this value to 32. And zabbix-agent in 64bit is never installed even if ansible_architecture is 64bit.

**Type of change**
Move up task 'Override architecture if 64-bit' to override 'windows_arch' value before use it. 

Feature Pull Request
Bugfix Pull Request
Docs Pull Request

**Fixes an issue**
The issue is not visible by ansible. But the main issue is : if the OS archi is 64bit, the version of zabbix-agent version 32bit is always installed.

After the change : 
<img width="410" alt="Capture d’écran 2020-01-30 à 14 48 03" src="https://user-images.githubusercontent.com/8749385/73455085-a95b8680-436f-11ea-937e-93f955f8eb5a.png">

Before it was 'win32'.
Tested with Ansible 2.9.0 on Windows 2016 Server. 