### PR TITLE
fix check mode on Windows

### DIFF
--- a/tasks/Windows.yml
+++ b/tasks/Windows.yml
@@ -146,6 +146,7 @@
   win_shell: sc.exe qfailure "Zabbix Agent" 1100
   register: svc_recovery
   changed_when: false
+  check_mode: false
   when: zabbix_agent_win_svc_recovery
 
 - name: "Windows | Setting Zabbix Service Recovery"


### PR DESCRIPTION
**Description of PR**

Fix  this error when doing a dry-run

```
TASK [dj-wasabi.zabbix-agent : Windows | Setting Zabbix Service Recovery] *******************************************************************************************************************************************************************
fatal: [xxxxxxx]: FAILED! => {"msg": "The conditional check ''RESTART -- Delay' not in svc_recovery.stdout' failed. The error was: error while evaluating conditional ('RESTART -- Delay' not in svc_recovery.stdout): Unable to look up a name or access an attribute in template string ({% if 'RESTART -- Delay' not in svc_recovery.stdout %} True {% else %} False {% endif %}).\nMake sure your variable name does not contain invalid characters like '-': argument of type 'AnsibleUndefined' is not iterable\n\nThe error appears to be in '/home/poil/git/xxxxxxroles/dj-wasabi.zabbix-agent/tasks/Windows.yml': line 150, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: \"Windows | Setting Zabbix Service Recovery\"\n  ^ here\n"}
```

**Type of change**
Bugfix Pull Request
