### PR TITLE
Apply proxy settings when installing deb-src repositories

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -47,12 +47,12 @@
     - zabbix-agent
     - init
 
-- name: "Debian | Installing deb-src repository Ubuntu"
+- name: "Debian | Installing deb-src repository Debian"
   apt_repository:
-    repo: "deb-src http://repo.zabbix.com/zabbix/{{ zabbix_version }}/ubuntu/ {{ zabbix_agent_distribution_release }} main"
+    repo: "deb-src http://repo.zabbix.com/zabbix/{{ zabbix_version }}/debian/ {{ zabbix_agent_distribution_release }} main"
     state: present
   when:
-    - ansible_distribution == "Ubuntu"
+    - ansible_distribution == "Debian"
     - zabbix_repo == "zabbix"
   become: yes
   tags:
@@ -71,12 +71,12 @@
     - zabbix-agent
     - init
 
-- name: "Debian | Installing deb-src repository Debian"
+- name: "Debian | Installing deb-src repository Ubuntu"
   apt_repository:
-    repo: "deb-src http://repo.zabbix.com/zabbix/{{ zabbix_version }}/debian/ {{ zabbix_agent_distribution_release }} main"
+    repo: "deb-src http://repo.zabbix.com/zabbix/{{ zabbix_version }}/ubuntu/ {{ zabbix_agent_distribution_release }} main"
     state: present
   when:
-    - ansible_distribution == "Debian"
+    - ansible_distribution == "Ubuntu"
     - zabbix_repo == "zabbix"
   become: yes
   tags:

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -51,6 +51,9 @@
   apt_repository:
     repo: "deb-src http://repo.zabbix.com/zabbix/{{ zabbix_version }}/debian/ {{ zabbix_agent_distribution_release }} main"
     state: present
+  environment:
+    http_proxy: "{{ zabbix_http_proxy | default(None) | default(omit) }}"
+    https_proxy: "{{ zabbix_https_proxy | default(None) | default(omit) }}"
   when:
     - ansible_distribution == "Debian"
     - zabbix_repo == "zabbix"
@@ -63,6 +66,9 @@
   apt_repository:
     repo: "deb http://repo.zabbix.com/zabbix/{{ zabbix_version }}/debian/ {{ zabbix_agent_distribution_release }} main"
     state: present
+  environment:
+    http_proxy: "{{ zabbix_http_proxy | default(None) | default(omit) }}"
+    https_proxy: "{{ zabbix_https_proxy | default(None) | default(omit) }}"
   when:
     - ansible_distribution == "Debian"
     - zabbix_repo == "zabbix"
@@ -75,6 +81,9 @@
   apt_repository:
     repo: "deb-src http://repo.zabbix.com/zabbix/{{ zabbix_version }}/ubuntu/ {{ zabbix_agent_distribution_release }} main"
     state: present
+  environment:
+    http_proxy: "{{ zabbix_http_proxy | default(None) | default(omit) }}"
+    https_proxy: "{{ zabbix_https_proxy | default(None) | default(omit) }}"
   when:
     - ansible_distribution == "Ubuntu"
     - zabbix_repo == "zabbix"
@@ -87,6 +96,9 @@
   apt_repository:
     repo: "deb http://repo.zabbix.com/zabbix/{{ zabbix_version }}/ubuntu/ {{ zabbix_agent_distribution_release }} main"
     state: present
+  environment:
+    http_proxy: "{{ zabbix_http_proxy | default(None) | default(omit) }}"
+    https_proxy: "{{ zabbix_https_proxy | default(None) | default(omit) }}"
   when:
     - ansible_distribution == "Ubuntu"
     - zabbix_repo == "zabbix"


### PR DESCRIPTION
**Description of PR**
The tasks for installing the deb-src repositories executing some cache updates from the package servers. Unfortunately these have been failing while the actual installation of zabbix-agent was succeeding.
This PR is adding the same proxy settings when installing deb-src repositories as when installing the agent. And trying to bring some order in the sequence.

**Type of change**
Bugfix Pull Request