### PR TITLE
Use proxy if defined (Windows)

### DIFF
--- a/tasks/Windows.yml
+++ b/tasks/Windows.yml
@@ -106,9 +106,7 @@
     dest: '{{ zabbix_win_install_dir }}\{{ zabbix_win_package }}'
     force: False
     follow_redirects: all
-  environment:
-    http_proxy: "{{ zabbix_http_proxy | default(None) | default(omit) }}"
-    https_proxy: "{{ zabbix_https_proxy | default(None) | default(omit) }}"
+    proxy_url: "{{ zabbix_https_proxy | default(None) | default(omit) }}"
   register: zabbix_agent_win_download_zip
   until: zabbix_agent_win_download_zip is succeeded
 


### PR DESCRIPTION
**Description of PR**
It seems that `win_get_url` doesn't use env vars for proxies, and has a direct config option.

**Type of change**
Bugfix Pull Request
