### PR TITLE
setting value for zabbix_agent_ipmi_authtype and zabbix_agent_ipmi_privilege

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -130,9 +130,9 @@ zabbix_agent_tls_config:
   cert: '4'
 
 # IPMI settings
-zabbix_agent_ipmi_authtype:
+zabbix_agent_ipmi_authtype: 2
 zabbix_agent_ipmi_password:
-zabbix_agent_ipmi_privilege:
+zabbix_agent_ipmi_privilege: 2
 zabbix_agent_ipmi_username:
 
 # Windows/macOS Related


### PR DESCRIPTION
**Description of PR**

Setting default values of those vars:
zabbix_agent_ipmi_authtype: 2
zabbix_agent_ipmi_privilege: 2

Documentation says that those are default, but that doesn't seem to work.

**Type of change**

Bugfix Pull Request

**Fixes an issue**

When running ansible-playbook with role, following error is returned:

`argument ipmi_authtype is of type <class 'str'> and we were unable to convert to int: <class 'str'> cannot be converted to an int`