### PR TITLE
adding empty dict to zabbix_agent_inventory_zabbix

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -110,7 +110,7 @@ zabbix_agent_loadmodulepath: ${libdir}/modules
 zabbix_agent_loadmodule:
 zabbix_agent_become_on_localhost: True
 zabbix_agent_description:
-zabbix_agent_inventory_zabbix:
+zabbix_agent_inventory_zabbix: {}
 
 # TLS settings
 zabbix_agent_tlsconnect:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -120,7 +120,7 @@
     tls_connect: "{{ zabbix_agent_tls_config[zabbix_agent_tlsconnect if zabbix_agent_tlsconnect else 'unencrypted'] }}"
     validate_certs: "{{ zabbix_validate_certs | default(omit) }}"
     description: "{{ zabbix_agent_description | default(omit) }}"
-    inventory_zabbix: "{{ zabbix_agent_inventory_zabbix | default(omit) }}"
+    inventory_zabbix: "{{ zabbix_agent_inventory_zabbix | default({}) }}"
     ipmi_authtype: "{{ zabbix_agent_ipmi_authtype | default(omit) }}"
     ipmi_password: "{{ zabbix_agent_ipmi_password| default(omit) }}"
     ipmi_privilege: "{{ zabbix_agent_ipmi_privilege | default(omit) }}"


### PR DESCRIPTION
**Description of PR**

Setting default of `zabbix_agent_inventory_zabbix` to dict in defaults/main.yml

```
zabbix_agent_inventory_zabbix: {}
```

Switching from `default(omit)` to `default({})` in tasks.main.yml

```
inventory_zabbix: "{{ zabbix_agent_inventory_zabbix | default({}) }}"
```

**Type of change**

Bugfix Pull Request

**Fixes an issue**

https://github.com/dj-wasabi/ansible-zabbix-agent/issues/317

When running ansible-playbook with role, following error is returned:

```argument inventory_zabbix is of type <class 'str'> and we were unable to convert to dict: dictionary requested, could not parse JSON or key=value```
