### PR TITLE
Add support for XCP-ng as a dialect of RHEL7

### DIFF
--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -39,6 +39,12 @@
   when:
     - ansible_distribution == "Fedora"
 
+- name: "XCP-ng | Override zabbix_agent_distribution_major_version for XCP-ng"
+  set_fact:
+    zabbix_agent_distribution_major_version: 7
+  when:
+    - ansible_distribution == "XCP-ng"
+
 - name: "RedHat | Install basic repo file"
   yum_repository:
     name: "{{ item.name }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,6 +14,12 @@
   when:
     - ansible_os_family == "Linuxmint"
 
+- name: "Fix facts for XCP-ng - family"
+  set_fact:
+    zabbix_agent_os_family: RedHat
+  when:
+    - ansible_os_family == "XCP-ng"
+
 - name: "Include OS-specific variables"
   include_vars: "{{ zabbix_agent_os_family }}.yml"
   tags:


### PR DESCRIPTION
**Description of PR**

XCP-ng [1] (formerly known as XenServer) belongs to the RHEL-based operating
systems. Unfortunately, release version 8 of XCP-ng is still based on RHEL 7.

These facts are fixed the same way it was done for some similar cases.

[1] https://xcp-ng.org/


**Type of change**

Feature Pull Request
