### PR TITLE
Fix: Changed apt state to present from installed.

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -172,7 +172,7 @@
 - name: "Install policycoreutils-python"
   apt:
     pkg: policycoreutils-python-utils
-    state: installed
+    state: present
     update_cache: yes
     cache_valid_time: 0
     force_apt_get: "{{ zabbix_apt_force_apt_get }}"


### PR DESCRIPTION
state: istalled is deprecated.

**Description of PR**
<!--- Describe what the PR holds -->

**Type of change**
<!--- Pick one below and delete the rest: -->

Feature Pull Request
Bugfix Pull Request
Docs Pull Request

**Fixes an issue**
<!--- If this PR fixes an issue, please mention it. -->
