### PR TITLE
Update Debian.yml

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -58,7 +58,7 @@
   when:
     - ansible_distribution == "Debian"
     - zabbix_repo == "zabbix"
-    - zabbix_agent_distribution_release is version('3.4', '>=')"
+    - "zabbix_agent_distribution_release is version('3.4', '>=')"
   become: yes
   tags:
     - zabbix-agent
@@ -89,7 +89,7 @@
   when:
     - ansible_distribution == "Ubuntu"
     - zabbix_repo == "zabbix"
-    - zabbix_agent_distribution_release is version('3.4', '>=')"
+    - "zabbix_agent_distribution_release is version('3.4', '>=')"
 
   become: yes
   tags:

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -58,6 +58,7 @@
   when:
     - ansible_distribution == "Debian"
     - zabbix_repo == "zabbix"
+    - zabbix_agent_distribution_release is version('3.4', '>=')"
   become: yes
   tags:
     - zabbix-agent
@@ -88,6 +89,8 @@
   when:
     - ansible_distribution == "Ubuntu"
     - zabbix_repo == "zabbix"
+    - zabbix_agent_distribution_release is version('3.4', '>=')"
+
   become: yes
   tags:
     - zabbix-agent


### PR DESCRIPTION
It seems that v3.0 of Zabbix doesn't have the source packages in the zabbix repo.

**Description of PR**
Added a check if the version of zabbix is 3.4 or newer because the older versions for Debian at least don't have the source packages

**Type of change**
<!--- Pick one below and delete the rest: -->
Bugfix Pull Request


**Fixes an issue**
<!--- If this PR fixes an issue, please mention it. -->
